### PR TITLE
Only close document with Word

### DIFF
--- a/src/RPA/core/msoffice.py
+++ b/src/RPA/core/msoffice.py
@@ -52,6 +52,7 @@ class OfficeApplication:
 
     def quit_application(self, save_changes: bool = False) -> None:
         if hasattr(self, "app") and self.app is not None:
-            self.close_document(save_changes)
+            if self.application_name == "Word":
+                self.close_document(save_changes)
             self.app.Quit()
             self.app = None


### PR DESCRIPTION
This currently fails with Excel because it does not have an "ActiveDocument" to call "Close" on. As far as I can tell, this is only available to Word.

The following code (from the example docs) will fail when 'quit_application()' is called:

```python
from RPA.Excel.Application import Application

def modify_excel():
    app = Application()
    app.open_application(visible=True, display_alerts=True)
    app.open_workbook('workbook.xlsx')
    app.set_active_worksheet(sheetname='Sheet1')
    app.write_to_cells(row=1, column=1, value='new data')
    app.save_excel()
    app.quit_application()

if __name__ == "__main__":
    modify_excel()
```