### PR TITLE
add exists_ok parameter to Files.create_dir

### DIFF
--- a/packages/main/src/RPA/FileSystem.py
+++ b/packages/main/src/RPA/FileSystem.py
@@ -283,36 +283,36 @@ class FileSystem:
         with open(path, "ab") as fd:
             fd.write(content)
 
-    def create_directory(self, path, parents=False, exists_ok=True):
+    def create_directory(self, path, parents=False, exist_ok=True):
         """Creates a directory and (optionally) non-existing parent directories.
 
         :param path:        path to new directory
         :param parents:     create missing parent directories
-        :param exists_ok:   FileExistsError is ignored if path is an existing directory
+        :param exist_ok:    FileExistsError is ignored if directory already exists
         """
-        Path(path).mkdir(parents=parents, exist_ok=exists_ok)
+        Path(path).mkdir(parents=parents, exist_ok=exist_ok)
 
-    def remove_file(self, path, force=False):
+    def remove_file(self, path, missing_ok=True):
         """Removes the given file.
 
-        :param path:    path to the file to remove
-        :param force:   ignore non-existent files
+        :param path:        path to the file to remove
+        :param missing_ok:  ignore non-existent file
         """
         try:
             Path(path).unlink()
         except FileNotFoundError:
-            if not force:
+            if not missing_ok:
                 raise
 
-    def remove_files(self, *paths, force=False):
+    def remove_files(self, *paths, missing_ok=True):
         """Removes multiple files.
 
-        :param paths:   paths to files to be removed
-        :param force:   ignore non-existent files
+        :param paths:       paths to files to be removed
+        :param missing_ok:  ignore non-existent files
         """
         # TODO: glob support
         for path in paths:
-            self.remove_file(path, force)
+            self.remove_file(path, missing_ok=missing_ok)
 
     def remove_directory(self, path, recursive=False):
         """Removes the given directory, and optionally everything it contains.

--- a/packages/main/src/RPA/FileSystem.py
+++ b/packages/main/src/RPA/FileSystem.py
@@ -283,13 +283,14 @@ class FileSystem:
         with open(path, "ab") as fd:
             fd.write(content)
 
-    def create_directory(self, path, parents=False):
+    def create_directory(self, path, parents=False, exists_ok=True):
         """Creates a directory and (optionally) non-existing parent directories.
 
         :param path:        path to new directory
         :param parents:     create missing parent directories
+        :param exists_ok:   FileExistsError is ignored if path is an existing directory
         """
-        Path(path).mkdir(parents=parents)
+        Path(path).mkdir(parents=parents, exist_ok=exists_ok)
 
     def remove_file(self, path, force=False):
         """Removes the given file.


### PR DESCRIPTION
Added support to exists_ok parameter in Files.create_dir.
This changes the default behaviour to not raise an FileExistsError if directory already exists.
