### PR TITLE
correct error message

### DIFF
--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -150,7 +150,7 @@ class ImapSmtp:
                 try:
                     self.smtp_conn.starttls()
                 except SMTPNotSupportedError:
-                    self.logger.warning("SMTP not supported by the server")
+                    self.logger.warning("TLS not supported by the server")
             except SMTPConnectError:
                 context = ssl.create_default_context()
                 self.smtp_conn = SMTP_SSL(smtp_server, smtp_port, context=context)


### PR DESCRIPTION
original warned about SMTP server not supporting SMTP when it only did not support TLS but worked fine anyway.