### PR TITLE
Let load_by_name return both resolved locator string and the data dictionary

### DIFF
--- a/packages/core/src/RPA/core/locators.py
+++ b/packages/core/src/RPA/core/locators.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 from contextlib import contextmanager
+from typing import Tuple
 
 DEFAULT_DATABASE = "locators.json"
 
@@ -34,7 +35,7 @@ def open_stream(obj, *args, **kwargs):
             obj.close()
 
 
-def load_by_name(path, criteria):
+def load_by_name(path, name) -> Tuple[str, dict]:
     db = LocatorsDatabase(path)
     if not os.path.exists(db.path):
         db.logger.warning("File does not exist: %s", db.path)
@@ -44,16 +45,14 @@ def load_by_name(path, criteria):
         error_msg, error_args = db.error
         raise ValidationError(error_msg % error_args)
 
-    entry = db.find_by_name(criteria)
+    entry = db.find_by_name(name)
     if not entry:
-        raise ValueError(f"Unknown locator alias: {criteria}")
+        raise ValueError(f"Unknown locator alias: {name}")
 
-    locator = "{prefix}:{criteria}".format(
-        prefix=entry["strategy"], criteria=entry["value"]
-    )
+    locator = "{prefix}:{name}".format(prefix=entry["strategy"], name=entry["value"])
 
-    db.logger.info("%s is an alias for %s", criteria, locator)
-    return locator
+    db.logger.info("%s is an alias for %s", name, locator)
+    return locator, entry
 
 
 class ValidationError(ValueError):

--- a/packages/core/tests/test_locators.py
+++ b/packages/core/tests/test_locators.py
@@ -73,7 +73,9 @@ def test_load_malformed():
 
 def test_find_by_name_or_error_missing():
     with pytest.raises(ValueError):
-        locators.load_by_name("/not/a/valid/path", "nonexistent locator name")
+        locator, locator_data = locators.load_by_name(
+            "/not/a/valid/path", "nonexistent locator name"
+        )
 
 
 def test_load_missing():


### PR DESCRIPTION
This will be useful for parsed locator validation (necessary for doing the call site check that a locator actually is type `browser` for example).