### PR TITLE
Cleaning up loose ends after Browser rename

### DIFF
--- a/packages/main/README.rst
+++ b/packages/main/README.rst
@@ -181,11 +181,11 @@ After installation the libraries can be directly imported inside
 .. code:: robotframework
 
     *** Settings ***
-    Library    RPA.Browser
+    Library    RPA.Browser.Selenium
 
     *** Tasks ***
     Login as user
-        Open browser  https://example.com
+        Open available browser    https://example.com
         Input text    id:user-name    ${USERNAME}
         Input text    id:password     ${PASSWORD}
 
@@ -193,11 +193,11 @@ The libraries are also available inside Python_:
 
 .. code:: python
 
-    from RPA.Browser import Browser
+    from RPA.Browser.Selenium import Selenium
 
-    lib = Browser()
+    lib = Selenium()
 
-    lib.open_browser("https://example.com")
+    lib.open_available_browser("https://example.com")
     lib.input_text("id:user-name", username)
     lib.input_text("id:password", password)
 

--- a/packages/main/src/RPA/Browser/Playwright.py
+++ b/packages/main/src/RPA/Browser/Playwright.py
@@ -1,9 +1,5 @@
 try:
-    from Browser import (
-        Browser as Playwright,
-    )
-
-    __all__ = ["Playwright"]
+    from Browser import Browser as Playwright  # noqa pylint: disable=unused-import
 except (ModuleNotFoundError, ImportError):
     raise ModuleNotFoundError(
         "Please install robotframework-browser following these instructions\n"

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -1537,11 +1537,14 @@ class Selenium(SeleniumLibrary):
             runnable_keyword(*args, **kwargs)
             return True
         except catches as e:
-            BuiltIn().log(
-                "Ran with keyword <b>%s</b> which returned error: <i>%s</i>"
-                % (runnable_keyword.__func__.__name__.replace("_", " ").title(), e),
-                html=True,
-            )
+            try:
+                BuiltIn().log(
+                    "Ran with keyword <b>%s</b> which returned error: <i>%s</i>"
+                    % (runnable_keyword.__func__.__name__.replace("_", " ").title(), e),
+                    html=True,
+                )
+            except RobotNotRunningError:
+                pass
             return False
 
     @keyword

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -40,7 +40,7 @@ class BrowserNotFoundError(ValueError):
     """Raised when browser can't be initialized."""
 
 
-class Browser(SeleniumLibrary):
+class Selenium(SeleniumLibrary):
     """Browser is a web testing library for Robot Framework,
     based on the popular SeleniumLibrary.
 
@@ -1689,3 +1689,8 @@ class Browser(SeleniumLibrary):
             for idx in range(len(elements))
         )
         self.driver.execute_script(script, *elements)
+
+
+# For backwards compatibility,
+# remove in next major version
+Browser = Selenium

--- a/packages/main/src/RPA/Browser/__init__.py
+++ b/packages/main/src/RPA/Browser/__init__.py
@@ -1,17 +1,9 @@
 import logging
-
-__all__ = ["Browser"]
-try:
-    from RPA.Browser.Playwright import Playwright
-
-    __all__.append("Playwright")
-except (ImportError, ModuleNotFoundError):
-    pass
-from RPA.Browser.Selenium import Browser as Selenium
+from RPA.Browser.Selenium import Selenium as _Selenium
 
 
-class Browser(Selenium):
-    __doc__ = Selenium.__doc__
+class Browser(_Selenium):
+    __doc__ = _Selenium.__doc__
 
     def __init__(self, *args, **kwargs):
         logging.warning(

--- a/packages/main/src/RPA/Dialogs.py
+++ b/packages/main/src/RPA/Dialogs.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote_plus
 import requests
 
 
-from RPA.Browser import Browser
+from RPA.Browser.Selenium import Selenium
 
 try:
     from importlib import import_module
@@ -273,7 +273,7 @@ class Dialogs:
     2. The HTML form is generated either according to a JSON file or the
        keywords called during the task
     3. It opens a browser and shows the created form (The browser is opened with
-       the ``Open Available Browser`` keyword from the ``RPA.Browser`` library)
+       the ``Open Available Browser`` keyword from the ``RPA.Browser.Selenium`` library)
     4. Once the form is filled and submitted by the user, the server will process
        the response and extract the field values, which in turn are returned by the keyword
     5. In the end, the browser is closed and the HTTP server is stopped
@@ -735,7 +735,7 @@ class Dialogs:
 
         response_json = {}
         try:
-            br = Browser()
+            br = Selenium()
             br.open_available_browser(f"{self.server_address}/form.html")
             br.set_window_size(window_width, window_height)
 

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -2,7 +2,9 @@ from unittest import TestCase
 
 
 class TestBrowserFunctionality(TestCase):
-    def test_import(self):
+    def test_imports(self):
         from RPA.Browser import Browser
+        from RPA.Browser.Selenium import Selenium
 
         Browser()
+        Selenium()

--- a/packages/main/tests/robot/test_browser.robot
+++ b/packages/main/tests/robot/test_browser.robot
@@ -1,5 +1,6 @@
 *** Settings ***
-Library         RPA.Browser    locators_path=${LOCATORS}  run_on_failure=${NONE}
+Library         RPA.Browser.Selenium    locators_path=${LOCATORS}
+Library         RPA.RobotLogListener
 Library         OperatingSystem
 Suite Setup     Open Available Browser  about:blank  headless=${TRUE}
 Suite Teardown  Close All Browsers
@@ -9,7 +10,6 @@ Default Tags    RPA.Browser
 ${RESOURCES}    ${CURDIR}${/}..${/}resources
 ${LOCATORS}     ${RESOURCES}${/}locators.json
 ${ALERT_HTML}   file://${RESOURCES}${/}alert.html
-
 
 *** Tasks ***
 Does alert contain
@@ -68,3 +68,14 @@ Clear all highlights
     Clear All Highlights
     Page Should Contain Element      xpath://h2
     Page Should Not Contain Element  xpath://h2[@rpaframework-highlight]
+
+Mute browser failures
+    Mute run on failure    My Custom Keyword
+    Open Available Browser    https://robotsparebinindustries.com/    headless=${TRUE}
+    Run keyword and expect error    *    My Custom Keyword
+    Run keyword and expect error    *    Get Value    id:notexist
+
+*** Keywords ***
+
+My Custom Keyword
+    Get Value    id:notexist


### PR DESCRIPTION
- Renamed `Browser` class to `Selenium`, added an alias to prevent breakage for quick 7.0.0 users
- Fixed all references in documentation from `RPA.Browser` to `RPA.Browser.Selenium `
- Added `Mute Run On Failure` support for both library names