### PR TITLE
Adding password type to the dialog

### DIFF
--- a/packages/main/src/RPA/Dialogs.py
+++ b/packages/main/src/RPA/Dialogs.py
@@ -113,6 +113,13 @@ class Handler(BaseHTTPRequestHandler):
             f"<label for=\"{item['name']}\">{item['label']}</label><br>"
             f"<input type=\"text\" name=\"{item['name']}\" value=\"{value}\"><br>"
         )
+    
+    def get_password(self, item):
+        value = item["value"] if "value" in item else ""
+        return (
+            f"<label for=\"{item['name']}\">{item['label']}</label><br>"
+            f"<input type=\"password\" name=\"{item['name']}\" value=\"{value}\"><br>"
+        )
 
     def get_hiddeninput(self, item):
         return (
@@ -462,6 +469,19 @@ class Dialogs:
         """
         element = {"type": "textinput", "label": label, "name": name, "value": value}
         self.custom_form["form"].append(element)
+                               
+    def add_password_input(self, label: str, name: str, value: str = None) -> None:
+        """Add password input element
+
+        :param label: input element label
+        :param name: input element name attribute
+        :param value: input element value attribute
+
+        Example:
+
+        """
+        element = {"type": "password", "label": label, "name": name, "value": value}
+        self.custom_form["form"].append(element)                      
 
     def add_hidden_input(self, name: str, value: str) -> None:
         """Add hidden input element

--- a/packages/main/src/RPA/Dialogs.py
+++ b/packages/main/src/RPA/Dialogs.py
@@ -33,6 +33,7 @@ try:
 except RobotNotRunningError:
     pass
 
+
 class Handler(BaseHTTPRequestHandler):
     """Server request handler class"""
 


### PR DESCRIPTION
Added the code to allow password type box to the dialog. You can test it with this:

```
from RPA.Dialogs import Dialogs

def ask_question_from_user(question, attribute):
    d = Dialogs()
    d.create_form('questions')
    d.add_text_input(label=question, name=attribute)
    d.add_password_input(label='Password:', name='password')
    response = d.request_response()
    return response

response = ask_question_from_user('What is your username ?', 'username')
print(f"Username is '{response['username']}'")
print(f"Password is '{response['password']}'")
```

Also in that example there is a correction to the one in [https://robocorp.com/docs/libraries/rpa-framework/rpa-dialogs](url), where in line 8 it does not have the `d.` before `request_response()`

Tested in Ubuntu 20 with python 3.8.5 with rpaframework 9.2.1 and robotframework 4.0.0 in Visual Studio Code

Edit: it would be a good thing to hide the password in the log. Selenium library does it, but i could not find how in order to replicate it here.