### PR TITLE
Bump version on using dialogs 0.4.0

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,6 +4,11 @@ Release notes
 Upcoming release
 ----------------
 
+11.2.0
+------
+
+- Library **RPA.Dialogs**: ``Add Date Input`` keyword
+
 11.1.3
 ------
 

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "11.1.3"
+version = "11.2.0"
 description = "A collection of tools and libraries for RPA"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",
@@ -38,7 +38,7 @@ docutils = "*"
 dataclasses = { version = "^0.7", python=">=3.6,<3.7" }
 rpaframework-core = "^6.4.0"
 rpaframework-pdf = "^0.8.0"
-rpaframework-dialogs = "^0.3.2"
+rpaframework-dialogs = "^0.4.0"
 rpaframework-recognition = { version = "^0.7.0", optional = true }
 jsonpath-ng = "^1.5.2"
 robotframework = ">=4.0.0,!=4.0.1,<5.0.0"


### PR DESCRIPTION
Adds support for `Add Date Input` keyword.

### ToDo

- [x] Publish **rpaframework-dialogs** `0.4.0` to PyPI
- [ ] Poetry packaging update, commit and push