### PR TITLE
Support yaml local vault secrets file

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -6,6 +6,7 @@ Upcoming release
 
 - Library **RPA.Robocorp.WorkItems**: New environment variables for work items I/O
   during local dev ("RPA_INPUT_WORKITEM_PATH", "RPA_OUTPUT_WORKITEM_PATH" - :pr:`234`)
+- Library **RPA.Robocorp.Vault**: Supports both .yaml/.json local vault secrets file
 
 11.2.1
 ------

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,7 +4,7 @@ Release notes
 Upcoming release
 ----------------
 
-- Library **RPA.Robocorp.Vault**: Supports both .yaml/.json local vault secrets file
+- Library **RPA.Robocorp.Vault**: Supports both .yaml/.json local vault secrets file formats (:issue:`225`)
 - Library **RPA.PDF**: Add possibility to preserve whitespacing in PDF textboxes - :issue:`235`
 - Library **RPA.Robocorp.WorkItems**: New environment variables for work items I/O
   during local dev ("RPA_INPUT_WORKITEM_PATH", "RPA_OUTPUT_WORKITEM_PATH" - :pr:`234`)

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,9 +4,9 @@ Release notes
 Upcoming release
 ----------------
 
+- Library **RPA.Robocorp.Vault**: Supports both .yaml/.json local vault secrets file
 - Library **RPA.Robocorp.WorkItems**: New environment variables for work items I/O
   during local dev ("RPA_INPUT_WORKITEM_PATH", "RPA_OUTPUT_WORKITEM_PATH" - :pr:`234`)
-- Library **RPA.Robocorp.Vault**: Supports both .yaml/.json local vault secrets file
 
 11.2.1
 ------

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -84,6 +84,9 @@ category = "main"
 optional = true
 python-versions = ">=3.6.0"
 
+[package.dependencies]
+typing = {version = ">=3.6", markers = "python_version < \"3.7\""}
+
 [[package]]
 name = "backports.zoneinfo"
 version = "0.2.1"
@@ -960,6 +963,18 @@ pyobjc-core = ">=7.3"
 pyobjc-framework-Cocoa = ">=7.3"
 
 [[package]]
+name = "pyobjc-framework-webkit"
+version = "7.3"
+description = "Wrappers for the framework WebKit on macOS"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyobjc-core = ">=7.3"
+pyobjc-framework-Cocoa = ">=7.3"
+
+[[package]]
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
@@ -1120,6 +1135,17 @@ python-versions = "*"
 six = ">=1.10.0"
 
 [[package]]
+name = "pythonnet"
+version = "2.5.2"
+description = ".Net and Mono integration for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -1138,6 +1164,11 @@ python-versions = "*"
 [package.dependencies]
 importlib_resources = {version = "*", markers = "python_version < \"3.7\""}
 proxy_tools = "*"
+pyobjc-core = {version = "*", markers = "sys_platform == \"darwin\""}
+pyobjc-framework-Cocoa = {version = "*", markers = "sys_platform == \"darwin\""}
+pyobjc-framework-WebKit = {version = "*", markers = "sys_platform == \"darwin\""}
+PyQt5 = {version = "*", markers = "sys_platform == \"openbsd6\""}
+pythonnet = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 cef = ["cefpython3"]
@@ -1164,6 +1195,14 @@ python-versions = "*"
 comtypes = "*"
 pywin32 = "*"
 six = "*"
+
+[[package]]
+name = "pyyaml"
+version = "5.4.1"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "regex"
@@ -1539,6 +1578,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "typing"
+version = "3.7.4.3"
+description = "Type Hints for Python"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -1698,7 +1745,7 @@ playwright = ["robotframework-browser"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "9a0ec2711b451a6869d777c3d4465324965cf111e93c66c02bee59ffe855ddb4"
+content-hash = "5ba20f4daf78deb02721ab0f8aa04af85c3fd0dd5fc8de5ef146736e23f4557a"
 
 [metadata.files]
 amazon-textract-response-parser = [
@@ -2493,6 +2540,11 @@ pyobjc-framework-quartz = [
     {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ddbca6b466584c3dc0e5b701b1c2a9b5d97ddc1d79a949927499ebb1be1f210"},
     {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7aba3cd966a0768dd58a35680742820f0c5ac596a9cd11014e2057818e65b0af"},
 ]
+pyobjc-framework-webkit = [
+    {file = "pyobjc-framework-WebKit-7.3.tar.gz", hash = "sha256:bec3a985c0f5e4263d6e28e2c551c1b5ec7b63950e0e3cb5409abdbf61f11f01"},
+    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:cd388df8fde96db724a42745395998b6d5a98740fb29bac95f76884e2fa6bf27"},
+    {file = "pyobjc_framework_WebKit-7.3-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:89e0fcc10eb09e4203b1ace02808ae9b1882b6c8a55bbfaff20213e2a62ce974"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
@@ -2595,6 +2647,19 @@ python-xlib = [
     {file = "python-xlib-0.31.tar.gz", hash = "sha256:74d83a081f532bc07f6d7afcd6416ec38403d68f68b9b9dc9e1f28fbf2d799e9"},
     {file = "python_xlib-0.31-py2.py3-none-any.whl", hash = "sha256:1ec6ce0de73d9e6592ead666779a5732b384e5b8fb1f1886bd0a81cafa477759"},
 ]
+pythonnet = [
+    {file = "pythonnet-2.5.2-cp27-cp27m-win32.whl", hash = "sha256:d519bbc7b1cd3999651efc594d91cb67c46d1d8466dad3d83b578102e58d05bd"},
+    {file = "pythonnet-2.5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:c02f53d0e61b202cddf3198fac9553d5b4ee0ea0cc4fe658c2ed69ab24def276"},
+    {file = "pythonnet-2.5.2-cp35-cp35m-win32.whl", hash = "sha256:840bdef89b378663d73f74f18895b6d8630d1f5671457a1db5ffb68179d85582"},
+    {file = "pythonnet-2.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:d8e5b27de1e2cfb69b88782ac5cdf605b1a73598a85d86570e46961126628dbb"},
+    {file = "pythonnet-2.5.2-cp36-cp36m-win32.whl", hash = "sha256:62645c29840c4a877d66e047f3e065b2e5a1a66431a99bce8d42a5af3a093ee1"},
+    {file = "pythonnet-2.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:058e536062d1585d07ec5f2cf16aefcfc8eb8179faa90e5db0063d358469d025"},
+    {file = "pythonnet-2.5.2-cp37-cp37m-win32.whl", hash = "sha256:cc77fc63e2afb0a80199ab44ced4fdfb78c19d8030063c345c80740d15380dd9"},
+    {file = "pythonnet-2.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:80c8f5c9bd10440a73eb6aedbbacb2f3dd7701b474816f5ef7636f529d838d38"},
+    {file = "pythonnet-2.5.2-cp38-cp38-win32.whl", hash = "sha256:41a607b7304e9efc6d4d8db438d6018a17c6637e8b8998848ff5c2a7a1b4687c"},
+    {file = "pythonnet-2.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:00a4fed9fc05b4efbe8947c79dc0799cffbca4c89e3e068e70b6618f20c906f2"},
+    {file = "pythonnet-2.5.2.tar.gz", hash = "sha256:b7287480a1f6ae4b6fc80d775446d8af00e051ca1646b6cc3d32c5d3a461ede3"},
+]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
@@ -2617,6 +2682,37 @@ pywin32 = [
 pywinauto = [
     {file = "pywinauto-0.6.8-py2.py3-none-any.whl", hash = "sha256:931ce622d7f402b1892ab472987a1332e4c0681bf87e106f798390d16ca95e58"},
     {file = "pywinauto-0.6.8.tar.gz", hash = "sha256:de23f1e977cc51e7eddd95c8f365710343136433968d1e2ad377962d6bd6540a"},
+]
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
     {file = "regex-2021.9.24-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0628ed7d6334e8f896f882a5c1240de8c4d9b0dd7c7fb8e9f4692f5684b7d656"},
@@ -2808,6 +2904,10 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+typing = [
+    {file = "typing-3.7.4.3-py2-none-any.whl", hash = "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"},
+    {file = "typing-3.7.4.3.tar.gz", hash = "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -75,6 +75,7 @@ click = "^7.1.2"
 boto3 = { version = "^1.13.4", optional = true }
 amazon-textract-response-parser = { version = "^0.1.1", optional = true }
 java-access-bridge-wrapper = "^0.7.4"
+PyYAML = "^5.4.1"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^21.5b0", allow-prereleases = true}

--- a/packages/main/src/RPA/Robocorp/Vault.py
+++ b/packages/main/src/RPA/Robocorp/Vault.py
@@ -159,7 +159,7 @@ class FileSecrets(BaseSecretManager):
             return {}
 
     def save(self):
-        """Save the secrets JSON to disk."""
+        """Save the secrets content to disk."""
         try:
             with open(self.path, "w", encoding="utf-8") as f:
                 if not isinstance(self.data, dict):

--- a/packages/main/src/RPA/Robocorp/Vault.py
+++ b/packages/main/src/RPA/Robocorp/Vault.py
@@ -88,14 +88,14 @@ class BaseSecretManager(metaclass=ABCMeta):
 
 
 class FileSecrets(BaseSecretManager):
-    """Adapter for secrets stored in a JSON file. Supports only
+    """Adapter for secrets stored in a database file. Supports only
     plaintext secrets, and should be used mainly for debugging.
 
     The path to the secrets file can be set with the
     environment variable ``RPA_SECRET_FILE``, or as
     an argument to the library.
 
-    The format of the secrets file should be the following:
+    The format of the secrets file should be one of the following:
 
     .. code-block:: JSON
 
@@ -108,6 +108,16 @@ class FileSecrets(BaseSecretManager):
           "key1": "value1"
         }
       }
+
+    OR
+
+    .. code-block:: YAML
+
+      name1:
+        key1: value1
+        key2: value2
+      name2:
+        key1: value1
     """
 
     LOADERS = {
@@ -422,7 +432,7 @@ class Vault:
     File-based secrets can be set by defining two environment variables.
 
     - ``RPA_SECRET_MANAGER``: RPA.Robocorp.Vault.FileSecrets
-    - ``RPA_SECRET_FILE``: Absolute path to the secrets JSON file
+    - ``RPA_SECRET_FILE``: Absolute path to the secrets database file
 
     Example content of local secrets file:
 
@@ -434,6 +444,14 @@ class Vault:
                 "password": "secret_sauce"
             }
         }
+
+    OR
+
+    .. code-block:: YAML
+
+        swaglabs:
+            username: standard_user
+            password: secret_sauce
 
     **Examples**
 

--- a/packages/main/src/RPA/Robocorp/Vault.py
+++ b/packages/main/src/RPA/Robocorp/Vault.py
@@ -134,8 +134,12 @@ class FileSecrets(BaseSecretManager):
 
         extension = self.path.suffix
         serializer = self.SERIALIZERS.get(extension)
+        # NOTE(cmin764): This will raise instead of returning an empty secrets object
+        #  because it is wrong starting from the "env.json" configuration level.
         if not serializer:
-            raise ValueError(f"Not supported local vault extension {extension!r}")
+            raise ValueError(
+                f"Not supported local vault secrets file extension {extension!r}"
+            )
         self._loader, self._dumper = serializer
 
         self.data = self.load()

--- a/packages/main/tests/python/test_robocorp_vault.py
+++ b/packages/main/tests/python/test_robocorp_vault.py
@@ -257,7 +257,7 @@ def test_adapter_filesecrets_saving(monkeypatch, tmp_path, secrets_file):
     else:
         loader = yaml.full_load
     secret_dict = loader(tmp_file.open())
-    secret_dict["credentials"]["sap"]["password"] = "my-different-secret"
+    assert secret_dict["credentials"]["sap"]["password"] == "my-different-secret"
 
 
 @mock.patch("RPA.Robocorp.Vault.requests")

--- a/packages/main/tests/resources/secrets.yaml
+++ b/packages/main/tests/resources/secrets.yaml
@@ -1,0 +1,17 @@
+credentials:
+    google:
+        apikey: '1234567890'
+    sap:
+        login: robot
+        password: secret
+robocorp:
+    login: robot
+    password: secret
+    url: http://robocorp.com/
+swaglabs:
+    password: secret_sauce
+    username: standard_user
+windows:
+    domain: windows
+    login: robot
+    password: secret

--- a/packages/main/tests/robot/test_robocorp_vault.robot
+++ b/packages/main/tests/robot/test_robocorp_vault.robot
@@ -2,21 +2,30 @@
 Suite setup     Set mock data
 Library         OperatingSystem
 Default Tags    RPA.Robocorp.Vault
+Test Template   File secrets
+
 
 *** Variables ***
 ${RESOURCES}      ${CURDIR}/../resources
 
-*** Tasks ***
-Swaglabs process
-    ${mysecret}=                Get secret   swaglabs
-    Should Be Equal As Strings  "${mysecret}[username]"   "standard_user"
-    Should Be Equal As Strings  "${mysecret}[password]"   "secret_sauce"
-
-Get non existing secret
-    Run Keyword And Expect Error   KeyError: 'Undefined secret: notexist'  Get secret  notexist
 
 *** Keywords ***
 Set mock data
     Set environment variable    RPA_SECRET_MANAGER    RPA.Robocorp.Vault.FileSecrets
-    Set environment variable    RPA_SECRET_FILE       \${RESOURCES}/secrets.json
     Import library   RPA.Robocorp.Vault
+
+
+File secrets
+    [Arguments]     ${secrets_file}
+    Set environment variable    RPA_SECRET_FILE       ${secrets_file}
+
+    ${mysecret}=                Get secret   swaglabs
+    Should Be Equal As Strings  "${mysecret}[username]"   "standard_user"
+    Should Be Equal As Strings  "${mysecret}[password]"   "secret_sauce"
+
+    Run Keyword And Expect Error   KeyError: 'Undefined secret: notexist'  Get secret  notexist
+
+
+*** Test Case ***                    SECRETS_FILE
+JSON secrets file                    \${RESOURCES}/secrets.json
+YAML secrets file                    \${RESOURCES}/secrets.yaml

--- a/packages/main/tests/robot/test_robocorp_vault.robot
+++ b/packages/main/tests/robot/test_robocorp_vault.robot
@@ -2,7 +2,7 @@
 Suite setup     Set mock data
 Library         OperatingSystem
 Default Tags    RPA.Robocorp.Vault
-Test Template   File secrets
+Task Template   File secrets
 
 
 *** Variables ***
@@ -26,6 +26,6 @@ File secrets
     Run Keyword And Expect Error   KeyError: 'Undefined secret: notexist'  Get secret  notexist
 
 
-*** Test Case ***                    SECRETS_FILE
+*** Tasks ***                    SECRETS_FILE
 JSON secrets file                    \${RESOURCES}/secrets.json
 YAML secrets file                    \${RESOURCES}/secrets.yaml


### PR DESCRIPTION
Tested with a _vault.yaml_ like this:
```yaml
urls:
  robot_order: 'https://robotsparebinindustries.com/#/robot-order'

```

from the legacy _vault.json_ file:
```json
{
    "urls": {
        "robot_order": "https://robotsparebinindustries.com/#/robot-order"
    }
}
```

### ToDo
- [x] Update docstrings
- [x] Add unit and robot tests for the yaml version
- [x] Release notes
- [x] Fix `File has tests but files parsed earlier have tasks. Fix headers or use '--rpa' or '--norpa' options to set the execution mode explicitly.` in [CI](https://github.com/robocorp/rpaframework/pull/240/checks?check_run_id=3746197141)
- [ ] Review, accept/refactor, squash-merge