### PR TITLE
Helper keyword for iterating local work items

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,6 +4,9 @@ Release notes
 Upcoming release
 ----------------
 
+- Library **RPA.Robocorp.WorkItems**: Add keyword `For Each Input Work Item` for applying a keyword over
+  all input work items in the local development queue (not supported yet in the cloud - :pr:`241`)
+
 11.3.0
 ------
 

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -849,6 +849,7 @@ class WorkItems:
                     "%s has unsaved changes that will be discarded", self.current
                 )
 
+    @keyword
     def set_current_work_item(self, item: WorkItem):
         """Set the currently active work item.
 

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -1275,7 +1275,7 @@ class WorkItems:
 
     @keyword
     def for_each_input_work_item(
-            self, keyword_or_func: Union[str, Callable], *args, **kwargs
+        self, keyword_or_func: Union[str, Callable], *args, **kwargs
     ) -> List[Any]:
         """Run a keyword or function for each work item in the input queue.
 
@@ -1325,9 +1325,11 @@ class WorkItems:
         self.raise_under_iteration("iterate input work items")
 
         if isinstance(keyword_or_func, str):
-            to_call = lambda: BuiltIn().run_keyword(keyword_or_func, *args, **kwargs)
+            to_call = lambda: BuiltIn().run_keyword(  # noqa: E731
+                keyword_or_func, *args, **kwargs
+            )
         else:
-            to_call = lambda: keyword_or_func(*args, **kwargs)
+            to_call = lambda: keyword_or_func(*args, **kwargs)  # noqa: E731
         outputs = []
 
         try:

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -407,12 +407,13 @@ class FileAdapter(BaseAdapter):
         return list(files.keys())
 
     def get_file(self, item_id: str, name: str) -> bytes:
-        _, item = self._get_item(item_id)
+        source, item = self._get_item(item_id)
         files = item.get("files", {})
 
         path = files[name]
         if not Path(path).is_absolute():
-            path = self.path.parent / path
+            parent = self.path.parent if source == "input" else self.output_path.parent
+            path = parent / path
 
         with open(path, "rb") as infile:
             return infile.read()
@@ -421,14 +422,14 @@ class FileAdapter(BaseAdapter):
         source, item = self._get_item(item_id)
         files = item.setdefault("files", {})
 
-        path = self.path.parent / name
+        parent = self.path.parent if source == "input" else self.output_path.parent
+        path = parent / name
         with open(path, "wb") as fd:
             fd.write(content)
         logging.info("Created file: %s", path)
         files[name] = str(path)
 
         self._save_to_disk(source)
-
 
     def remove_file(self, item_id: str, name: str):
         _, item = self._get_item(item_id)

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -377,7 +377,7 @@ class FileAdapter(BaseAdapter):
         with open(path, "w", encoding="utf-8") as fd:
             fd.write(json_dumps(data, indent=4))
 
-        logging.info("Saved into file: %s", path)
+        logging.info("Saved into %s file: %s", source, path)
 
     def create_output(self, _: str, payload: Optional[JSONType] = None) -> str:
         # Note that the `parent_id` is not used during local development.

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -1264,8 +1264,8 @@ class WorkItems:
 
         Returns a list of results.
         """
-        outputs = []
 
+        outputs = []
         while True:
             output = BuiltIn().run_keyword(keyword, *args, **kwargs)
             outputs.append(output)

--- a/packages/main/tests/python/test_robocorp_workitems.py
+++ b/packages/main/tests/python/test_robocorp_workitems.py
@@ -84,7 +84,7 @@ class MockAdapter(BaseAdapter):
     def get_file(self, item_id, name):
         return self.FILES[item_id][name]
 
-    def add_file(self, item_id, name, content):
+    def add_file(self, item_id, name, *, original_name, content):
         self.FILES[item_id][name] = content
 
     def remove_file(self, item_id, name):
@@ -505,7 +505,12 @@ class TestFileAdapter:
 
     def test_add_file(self, adapter):
         item_id = adapter.get_input()
-        adapter.add_file(item_id, "secondfile2.txt", b"somedata")
+        adapter.add_file(
+            item_id,
+            "secondfile2.txt",
+            original_name="secondfile2.txt",
+            content=b"somedata"
+        )
         assert adapter.inputs[0]["files"]["secondfile2.txt"] == "secondfile2.txt"
         assert os.path.isfile(Path(adapter.path).parent / "secondfile2.txt")
 

--- a/packages/main/tests/python/test_robocorp_workitems.py
+++ b/packages/main/tests/python/test_robocorp_workitems.py
@@ -5,7 +5,7 @@ import pytest
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from RPA.Robocorp.WorkItems import BaseAdapter, FileAdapter, WorkItems
+from RPA.Robocorp.WorkItems import BaseAdapter, EmptyQueue, FileAdapter, WorkItems
 
 
 VARIABLES_FIRST = {"username": "testguy", "address": "guy@company.com"}
@@ -58,16 +58,31 @@ class MockAdapter(BaseAdapter):
     FILES = {}
     INDEX = 0
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._data_keys = []
+
     @classmethod
     def validate(cls, item, key, val):
         data = cls.DATA.get(item.id)
         assert data is not None
         assert data[key] == val
 
+    @property
+    def data_keys(self):
+        if not self._data_keys:
+            self._data_keys = list(self.DATA.keys())
+        return self._data_keys
+
     def get_input(self) -> str:
-        idx = self.INDEX
-        self.INDEX += 1
-        return list(self.DATA.keys())[idx]
+        if self.INDEX >= len(self.data_keys):
+            raise EmptyQueue("No work items in the input queue")
+
+        try:
+            return self.data_keys[self.INDEX]
+        finally:
+            self.INDEX += 1
 
     def create_output(self, parent_id, payload=None) -> str:
         raise NotImplementedError
@@ -460,6 +475,27 @@ class TestLibrary:
             "vars": {"cool": "beans", "yeah": "boi"},
         }
 
+    def test_iter_work_items(self, library):
+        usernames = []
+
+        def func():
+            # Collects the "username" variable from the payload if provided and returns
+            #   True if found, False otherwise.
+            payload = library.get_work_item_payload()
+            if not isinstance(payload, dict):
+                return False
+
+            username = payload.get("username")
+            if username:
+                usernames.append(username)
+            return username is not None
+
+        library.get_input_work_item()
+        results = library.for_each_input_work_item(func)
+
+        assert usernames == ["testguy", "another"]
+        assert results == [True, True, False]
+
 
 class TestFileAdapter:
     """Tests the local dev env `FileAdapter` on Work Items."""
@@ -507,11 +543,11 @@ class TestFileAdapter:
         item_id = adapter.get_input()
         adapter.add_file(
             item_id,
-            "secondfile2.txt",
+            "secondfile.txt",
             original_name="secondfile2.txt",
-            content=b"somedata"
+            content=b"somedata",
         )
-        assert adapter.inputs[0]["files"]["secondfile2.txt"] == "secondfile2.txt"
+        assert adapter.inputs[0]["files"]["secondfile.txt"] == "secondfile2.txt"
         assert os.path.isfile(Path(adapter.path).parent / "secondfile2.txt")
 
     def test_save_data_input(self, adapter):

--- a/packages/main/tests/resources/items.json
+++ b/packages/main/tests/resources/items.json
@@ -4,5 +4,11 @@
             "workspace": "Example workspace",
             "user_id": "Example user id"
         }
+    },
+    {
+        "payload": {
+            "workspace": "Another example workspace",
+            "user_id": "Another example user id"
+        }
     }
 ]

--- a/packages/main/tests/robot/test_robocorp_workitems.robot
+++ b/packages/main/tests/robot/test_robocorp_workitems.robot
@@ -1,16 +1,39 @@
 *** Settings ***
-Suite setup    Load mock library
+Test Setup     Load mock library
 Library        OperatingSystem
+
 
 *** Variables ***
 ${RESOURCES}    ${CURDIR}/../resources
 ${RESULTS}      ${CURDIR}/../results
 ${temp_in}      ${RESOURCES}/temp_items.json
 ${temp_out}     ${RESULTS}/output_dir/temp_items.json
+${first_item}   None
+
+
+*** Keywords ***
+Load mock library
+    Copy file    ${RESOURCES}/items.json    ${temp_in}
+    Set environment variable    RPA_INPUT_WORKITEM_PATH    ${temp_in}
+    Set environment variable    RPA_OUTPUT_WORKITEM_PATH    ${temp_out}
+
+    Import library    RPA.Robocorp.WorkItems    autoload=${FALSE}    default_adapter=FileAdapter
+    IF  ${first_item}
+        Set Current Work Item     ${first_item}
+    ELSE
+        ${item} =     Get Input Work Item  # because auto-load is disabled with this test
+        Set Global Variable     ${first_item}   ${item}
+    END
+
+Log Payload
+    ${payload} =     Get Work Item Payload
+    Log To Console    ${payload}
+    ${len} =     Get Length    ${payload}
+    [Return]    ${len}
+
 
 *** Tasks ***
 Read input and write output
-    Get input work item
     Set task variables from work item
     Log   Using variables from workspace ${workspace} for user ${user_id}
     Set work item variables    user=Dude    mail=address@company.com
@@ -23,9 +46,7 @@ Read input and write output
 
     [Teardown]  Remove file     ${temp_out}
 
-*** Keywords ***
-Load mock library
-    Copy file    ${RESOURCES}/items.json    ${temp_in}
-    Set environment variable    RPA_INPUT_WORKITEM_PATH    ${temp_in}
-    Set environment variable    RPA_OUTPUT_WORKITEM_PATH    ${temp_out}
-    Import library    RPA.Robocorp.WorkItems    autoload=${FALSE}    default_adapter=FileAdapter
+Consume queue
+    @{results} =     For Each Input Work Item    Log Payload
+    Log   Items keys length: @{results}
+    Length should be    ${results}  2


### PR DESCRIPTION
Add `@{results} =     For Each Input Work Item    <keyword>    <params>` keyword for consuming all work items in the local queue while applying a keyword over them.

Example
```robotframework
*** Settings ***
Documentation    Testing the helper keyword on consuming all work items in the queue.
Library          RPA.Robocorp.WorkItems
Library          OperatingSystem
Library          Collections


*** Variables ***
${idx}    ${1}


*** Keywords ***
Add Work Item
    [Arguments]  ${counter}

    # Get files from the current input work item.
    ${path} =        Get Work Item File    orders.txt    path=${OUTPUT_DIR}${/}orders${counter}.txt
    Log To Console    Getting: ${path}
    ${content} =     Get File    ${path}

    # Save a new file with the same content into one adjacent output work item.
    Create Output Work Item
    Set work item variables    name=CustomName${counter}   id=${counter}
    Add Work Item File    devdata/orders${counter}.txt
    Save Work Item
    [Return]    ${content}

Add Work Item Wrapper
    ${ret} =    Add Work Item    ${idx}
    Set Global Variable    ${idx}    ${idx + 1}

    # Any of these would fail if uncommented
    # Get Input Work Item
    # @{results} =     For Each Input Work Item    Add Work Item Wrapper
    
    [Return]    ${ret}


*** Tasks ***
Consume queue
    @{results} =     For Each Input Work Item    Add Work Item Wrapper
    Log List    ${results}
```

For the whole robot content including the prebuilt wheel with the changes in this PR see the attached archive. (make sure you rebuild your `rcc` env by removing the old one)

Latest robot (**4 Oct**): [work-items-matti.zip](https://github.com/robocorp/rpaframework/files/7278234/work-items-matti.zip)

_env.json_
```JSON
{
    "RPA_WORKITEMS_ADAPTER": "RPA.Robocorp.WorkItems.FileAdapter",
    "RPA_INPUT_WORKITEM_PATH": "%{ROBOT_ROOT}/devdata/items-in.json",
    "RPA_OUTPUT_WORKITEM_PATH": "%{ROBOT_ROOT}/output/items-out.json"
}
```

Look into the attached archive for the rest of the required files.

If it works, you should see some console output like so:
```console
Consume queue                                                         Getting: /Users/cmin/Robots/work-items-matti/output/orders1.txt
Getting: /Users/cmin/Robots/work-items-matti/output/orders2.txt
Getting: /Users/cmin/Robots/work-items-matti/output/orders3.txt
| PASS |
```

### Notes
- [Bugs](https://linear.app/robocorp/issue/LIB-12/fix-looping-of-work-items-bug) fixed
- While iterating work items already you can't (inside the iteration):
    - Iterate work items with the helper
    - Pull new input work items
    - Do it in the cloud (for now)

### ToDo
- [x] Confirmation from @janipalsamaki that this keyword works as expected
- [x] Unit and robot tests (adding/removing files under input/output work items, the helper keyword)
- [x] Review, refactor/accept,  release notes, squash-merge