### PR TITLE
Fix serialization issue on releasing exception

### DIFF
--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -1543,7 +1543,7 @@ class WorkItems:
         if state is State.FAILED:
             if exception_type:
                 exception = {
-                    "type": Error(exception_type),
+                    "type": Error(exception_type).value,
                     "code": code,
                     "message": message,
                 }

--- a/packages/main/tests/python/test_robocorp_workitems.py
+++ b/packages/main/tests/python/test_robocorp_workitems.py
@@ -635,7 +635,7 @@ class TestLibrary:
 
         exception_type = (exception or {}).pop("exception_type", None)
         if exception_type:
-            exception["type"] = Error(exception_type)
+            exception["type"] = Error(exception_type).value
             exception.setdefault("code", None)
             exception.setdefault("message", None)
         else:


### PR DESCRIPTION
I was sending an exception `Error` object instead of string given the `exception.type`, thus throwing JSON serialization exception.