### PR TITLE
Skip unexpected errors from retrying during work items API calls

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,6 +4,8 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++
 
+- Skip Control Room unexpected errors from retrying during API calls
+
 `Released <https://pypi.org/project/rpaframework/#history>`_
 +++++++++
 

--- a/packages/main/src/RPA/Robocorp/utils.py
+++ b/packages/main/src/RPA/Robocorp/utils.py
@@ -115,7 +115,7 @@ class Requests:
     def _needs_retry(exc: BaseException) -> bool:
         # Don't retry on server (500/internal/unexpected) and auth errors (401/403).
         no_retry_codes = [400, 401, 403, 409, 500]
-        no_retry_messages = ["ERR_UNEXPECTED"]
+        no_retry_messages = ["UNEXPECTED_ERROR"]
 
         if isinstance(exc, RequestsHTTPError):
             if (

--- a/packages/main/tests/python/test_robocorp_workitems.py
+++ b/packages/main/tests/python/test_robocorp_workitems.py
@@ -579,7 +579,7 @@ class TestLibrary:
             {"exception_type": "BUSINESS"},
             {
                 "exception_type": "APPLICATION",
-                "code": "ERR_UNEXPECTED",
+                "code": "UNEXPECTED_ERROR",
                 "message": "This is an unexpected error",
             },
             {
@@ -865,7 +865,7 @@ class TestRobocorpAdapter:
 
     @pytest.mark.parametrize(
         "exception",
-        [None, {"type": "BUSINESS", "code": "ERR_UNEXPECTED", "message": None}],
+        [None, {"type": "BUSINESS", "code": "UNEXPECTED_ERROR", "message": None}],
     )
     def test_release_input(self, adapter, exception):
         item_id = "26"
@@ -978,9 +978,9 @@ class TestRobocorpAdapter:
     @pytest.fixture(
         params=[
             # Requests response attribute values for: `.json()`, `.raise_for_status()`
-            ({"error": {"code": "ERR_UNEXPECTED"}}, None),  # normal response
-            ('{"error": {"code": "ERR_UNEXPECTED"}}', None),  # double serialized
-            (r'"{\"error\": {\"code\": \"ERR_UNEXPECTED\"}}"', None),  # triple
+            ({"error": {"code": "UNEXPECTED_ERROR"}}, None),  # normal response
+            ('{"error": {"code": "UNEXPECTED_ERROR"}}', None),  # double serialized
+            (r'"{\"error\": {\"code\": \"UNEXPECTED_ERROR\"}}"', None),  # triple
             ('[{"some": "value"}]', HTTPError()),  # double serialized list
         ]
     )
@@ -994,7 +994,7 @@ class TestRobocorpAdapter:
         with pytest.raises(RequestsHTTPError) as exc_info:
             adapter.list_files("4")
 
-        err = "ERR_UNEXPECTED"
+        err = "UNEXPECTED_ERROR"
         call_count = 1
         if err not in str(failing_deserializing_response.json.return_value):
             err = "Error"  # default error message in the absence of it


### PR DESCRIPTION
If `ERR_UNEXPECTED` just changed in the cloud into `UNEXPECTED_ERROR` (as **error.code**), then this needs to be reflected in the library as well in order to skip from retrying any unexpected error as well.

![image](https://user-images.githubusercontent.com/709053/140533121-ab5b557e-b7c1-4e62-8480-2b152869b91e.png)


- Slack [thread](https://robocorptechnologies.slack.com/archives/C013FUJQVL4/p1636122677117500)