### PR TITLE
feature/refresh-when-waiting added use_refreshing parameter to wait_for_element function

### DIFF
--- a/packages/main/src/RPA/Desktop/Windows.py
+++ b/packages/main/src/RPA/Desktop/Windows.py
@@ -1248,6 +1248,7 @@ class Windows(OperatingSystem):
     def wait_for_element(
         self,
         locator: str,
+        use_refreshing: bool = False,
         search_criteria: str = None,
         timeout: float = 30.0,
         interval: float = 2.0,
@@ -1258,6 +1259,7 @@ class Windows(OperatingSystem):
         `ElementNotFoundError` if element is not found within timeout.
 
         :param locator: name of the locator
+        :param use_refreshing: wait for element(s) which are not there yet e.g. listbox item or popups, default False
         :param search_criteria: criteria by which element is matched
         :param timeout: defines how long to wait for element to appear,
          defaults to 30.0 seconds
@@ -1278,6 +1280,8 @@ class Windows(OperatingSystem):
         elements = None
         while time.time() < end_time:
             elements, _ = self.find_element(locator, search_criteria)
+            if use_refreshing:
+                self.refresh_window()
             if len(elements) > 0:
                 break
             if interval >= timeout:


### PR DESCRIPTION
In many cases one wants to wait for an element which are not there yet, for example: listitems in listboxes. This feature enables you to refresh instantaneously while waiting.  