### PR TITLE
tables. add delimiter parameter to write_table_to_csv

### DIFF
--- a/packages/main/src/RPA/Tables.py
+++ b/packages/main/src/RPA/Tables.py
@@ -1840,6 +1840,7 @@ class Tables:
         header: bool = True,
         dialect: Dialect = Dialect.Excel,
         encoding: Optional[str] = None,
+        delimiter: Optional[str] = ",",
     ):
         """Write a table as a CSV file.
 
@@ -1849,6 +1850,7 @@ class Tables:
         :param dialect:  The format of output CSV
         :param encoding: Text encoding for output file,
                          uses system encoding by default
+        :param delimiter: Delimiter character between columns
 
         Valid ``dialect`` values are ``Excel``, ``ExcelTab``, and ``Unix``.
 
@@ -1865,7 +1867,9 @@ class Tables:
             dialect = Dialect(dialect)
 
         with open(path, mode="w", newline="", encoding=encoding) as fd:
-            writer = csv.DictWriter(fd, fieldnames=table.columns, dialect=dialect.value)
+            writer = csv.DictWriter(
+                fd, fieldnames=table.columns, dialect=dialect.value, delimiter=delimiter
+            )
 
             if header:
                 writer.writeheader()

--- a/packages/main/tests/python/test_tables.py
+++ b/packages/main/tests/python/test_tables.py
@@ -616,6 +616,14 @@ def test_keyword_write_table_to_csv_columns_range(library):
     assert data[0] == "0,1,2\n"
     assert data[1] == "1,2,3\n"
 
+def test_keyword_write_table_to_csv_delimiter(library, table):
+    with temppath() as path:
+        library.write_table_to_csv(table, path, encoding="utf-8", delimiter=";")
+        with open(path) as fd:
+            data = fd.readlines()
+
+    assert len(data) == 7
+    assert data[0] == "one;two;three;four\n"
 
 def test_import_with_integer_keys():
     data = [


### PR DESCRIPTION
```python
from RPA.Tables import Tables
from RPA.FileSystem import FileSystem


def minimal_task():
    files = FileSystem().list_files_in_directory()
    table = Tables().create_table(files)
    print(table)
    Tables().write_table_to_csv(table, "out.csv", delimiter=";")

    print("Done.")


if __name__ == "__main__":
    minimal_task()

```