### PR TITLE
Fix `Get Os Version` to return version properly

### DIFF
--- a/packages/windows/poetry.lock
+++ b/packages/windows/poetry.lock
@@ -125,7 +125,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "8.0.3"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
@@ -999,8 +999,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
-    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/packages/windows/pyproject.toml
+++ b/packages/windows/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-windows"
-version = "2.2.1"
+version = "2.2.2"
 description = "Windows library for RPA Framework"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",

--- a/packages/windows/src/RPA/Windows/keywords/window.py
+++ b/packages/windows/src/RPA/Windows/keywords/window.py
@@ -445,15 +445,14 @@ class WindowKeywords(LibraryContext):
         return closed
 
     @keyword(tags=["window"])
-    @with_timeout
     def get_os_version(self) -> str:
-        """Returns the current Windows version as string.
+        """Returns the current Windows major version as string.
 
         Example:
 
         .. code-block:: robotframework
 
             ${ver} =     Get OS Version
-            Log     ${ver}
+            Log     ${ver}  # 10
         """
         return utils.get_win_version()

--- a/packages/windows/src/RPA/Windows/utils.py
+++ b/packages/windows/src/RPA/Windows/utils.py
@@ -1,6 +1,5 @@
 from typing import Dict
 import platform
-import subprocess
 
 import psutil
 
@@ -35,11 +34,12 @@ def call_attribute_if_available(object_name, attribute_name):
 
 
 def get_win_version() -> str:
-    """Windows only utility which returns the current Windows version."""
-    output = subprocess.getoutput("ver")
+    """Windows only utility which returns the current Windows major version."""
     # Windows terminal `ver` command is bugged, until that's fixed, check by build
     #  number. (the same applies for `platform.version()`)
-    if int(output.split(".")[2]) >= 22000:
-        return "11"  # Windows 11
+    version_parts = platform.version().split(".")
+    major = version_parts[0]
+    if major == "10" and int(version_parts[2]) >= 22000:
+        major = "11"
 
-    return "10"  # Windows 10 (or lower)
+    return major

--- a/tools/tag.py
+++ b/tools/tag.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
+
+import platform
 import subprocess
 from pathlib import Path
 
 
 def run(*args):
-    return subprocess.check_output(args).decode().strip()
+    run_process = lambda params: subprocess.check_output(params).decode().strip()
+
+    try:
+        return run_process(args)
+    except FileNotFoundError:
+        if platform.system() != "Windows":
+            raise
+
+        # Edge-case for Windows 11 with different paths. (solved by absolute path)
+        abs_path = run_process(["where", args[0]]).splitlines()[-1]
+        return run_process((abs_path,) + args[1:])
 
 
 def main():


### PR DESCRIPTION
Uses `platform.version()` instead of subprocess-ing `ver` command and doesn't hardcode lower than "10" versions.