### PR TITLE
Option to windows list_windows to save icons to file

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "6.6.2"
+version = "6.6.3"
 description = "Core utilities used by RPA Framework"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",

--- a/packages/core/src/RPA/core/windows/window.py
+++ b/packages/core/src/RPA/core/windows/window.py
@@ -28,7 +28,7 @@ class Window:
         self.logger = logging.getLogger(__file__)
 
     @classmethod
-    def get_icon(cls, filepath: str, icon_save_directory: str = None) -> str:
+    def get_icon(cls, filepath: str, icon_save_directory: Optional[str] = None) -> str:
         image_string = None
         executable_path = Path(filepath)
         ico_x = win32api.GetSystemMetrics(win32con.SM_CXICON)

--- a/packages/core/src/RPA/core/windows/window.py
+++ b/packages/core/src/RPA/core/windows/window.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 from pathlib import Path
 from io import BytesIO
 import base64

--- a/packages/core/src/RPA/core/windows/window.py
+++ b/packages/core/src/RPA/core/windows/window.py
@@ -28,13 +28,14 @@ class Window:
         self.logger = logging.getLogger(__file__)
 
     @classmethod
-    def get_icon(cls, filepath: str) -> str:
+    def get_icon(cls, filepath: str, icon_save_directory: str = None) -> str:
         image_string = None
         executable_path = Path(filepath)
         ico_x = win32api.GetSystemMetrics(win32con.SM_CXICON)
         ico_y = win32api.GetSystemMetrics(win32con.SM_CYICON)
 
-        large, small = win32gui.ExtractIconEx(filepath, 0, 10)
+        # TODO. Get different size icons
+        small, large = win32gui.ExtractIconEx(filepath, 0, 10)
         if len(small) > 0:
             win32gui.DestroyIcon(small[0])
 
@@ -49,16 +50,21 @@ class Window:
         if len(large) > 0:
             hdc.DrawIcon((0, 0), large[0])
             result_image_file = f"icon_{executable_path.name}.bmp"
+            if icon_save_directory:
+                result_image_file = Path(icon_save_directory) / result_image_file
+                result_image_file = str(result_image_file.resolve())
             hbmp.SaveBitmapFile(hdc, result_image_file)
-            # signedIntsArray = hbmp.GetBitmapBits(True)
             with Image.open(result_image_file) as img:
                 buffered = BytesIO()
                 img.save(buffered, format="PNG")
                 image_string = base64.b64encode(buffered.getvalue())
-            Path(result_image_file).unlink()
+            if not icon_save_directory:
+                Path(result_image_file).unlink()
         return image_string
 
-    def list_windows(self, icons: bool = False) -> List[Dict]:
+    def list_windows(
+        self, icons: bool = False, icon_save_directory: str = None
+    ) -> List[Dict]:
         windows = auto.GetRootControl().GetChildren()
         process_list = get_process_list()
         win_list = []
@@ -77,7 +83,7 @@ class Window:
                 "name": process_list[pid] if pid in process_list else None,
                 "path": fullpath,
                 "handle": win.NativeWindowHandle,
-                "icon": self.get_icon(fullpath) if icons else None,
+                "icon": self.get_icon(fullpath, icon_save_directory) if icons else None,
             }
             win_list.append(info)
         return win_list

--- a/packages/core/src/RPA/core/windows/window.py
+++ b/packages/core/src/RPA/core/windows/window.py
@@ -63,7 +63,7 @@ class Window:
         return image_string
 
     def list_windows(
-        self, icons: bool = False, icon_save_directory: str = None
+        self, icons: bool = False, icon_save_directory: Optional[str] = None
     ) -> List[Dict]:
         windows = auto.GetRootControl().GetChildren()
         process_list = get_process_list()


### PR DESCRIPTION
Mika added an option to save icons to file when listing windows with Windows library.
Adding the code to core as I forgot to mention to Mika that code is moved there.

Mika also changed the icon fetching code to include the alpha channel, but that doesn't unfortunately work with all machines for some reason. See issue: https://stackoverflow.com/questions/63513150/issues-saving-frames-using-pil-in-python-images-come-out-distorted-on-my-pc-bu

I'll have to debug it later as I can reproduce it on my machine, but until then the code cannot be taken into use. The version in this review should go to windows library as well.