### PR TITLE
Fixed KeyError if using quit_application

### DIFF
--- a/packages/main/src/RPA/Desktop/Windows.py
+++ b/packages/main/src/RPA/Desktop/Windows.py
@@ -815,7 +815,7 @@ class Windows(OperatingSystem):
             self.quit_application(aid)
             del self._apps[aid]
 
-    def quit_application(self, app_id: str = None, send_keys: bool = False) -> None:
+    def quit_application(self, app_id: int = None, send_keys: bool = False) -> None:
         """Quit an application by application id or
         active application if `app_id` is None.
 


### PR DESCRIPTION
Wrong data type used for app_id in function arguments.