### PR TITLE
Fix `RPA.Database` config getter

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,7 +4,7 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-- Library **RPA.Database**: Fix configuration value retrieval.
+- Library **RPA.Database**: Fix configuration value retrieval. (:pr:`456`)
 
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
@@ -14,7 +14,7 @@ Release notes
 --------------------
 
 - Library **RPA.Database**: Fix queries with ``pyodbc`` module. (affects Microsoft SQL
-  Server)
+  Server, :issue:`443`)
 
 13.0.2 - 04 Apr 2022
 --------------------

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,6 +4,8 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.Database**: Fix configuration value retrieval.
+
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Database.py
+++ b/packages/main/src/RPA/Database.py
@@ -80,7 +80,9 @@ class Configuration:
         return self.module_name, self.configuration
 
     def get(self, param, default=None):
-        return self.configuration.get(param, default) or default
+        # Missing values are still present in configuration as nulls.
+        value = self.configuration.get(param)
+        return value if value is not None else default
 
     def set_val(self, param, value):
         self.configuration[param] = value


### PR DESCRIPTION
To cover cases when you set something evaluating to `False` in the configuration, like a `port=0`. (if ever happens)