### PR TITLE
Support single quotes in windows locator names | More windows listing attributes

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,6 +4,26 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.Windows** (:pr:`467`):
+
+  - Keyword ``List Windows`` returns now extra attributes similar to the old
+    deprecated ``RPA.Desktop.Windows`` library (:issue:`408`):
+
+    - ``automation_id``
+    - ``control_type``
+    - ``class_name``
+    - ``rectangle``
+    - ``keyboard_focus``
+    - ``is_active``
+    - ``object``
+
+  - Improved locators parsing and ability to enclose values containing spaces with
+    ``"`` double-quote (:issue:`363`).
+
+  .. warning::
+    This is a **breaking** change! If you use single-quote locator value enclosing,
+    please switch it to double-quote instead.
+
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/core/poetry.lock
+++ b/packages/core/poetry.lock
@@ -44,11 +44,11 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.10.0"
+version = "4.11.1"
 description = "Screen-scraping library"
 category = "main"
 optional = false
-python-versions = ">3.0.0"
+python-versions = ">=3.6.0"
 
 [package.dependencies]
 soupsieve = ">1.2"
@@ -488,7 +488,7 @@ urllib3 = "*"
 
 [[package]]
 name = "soupsieve"
-version = "2.3.1"
+version = "2.3.2"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "main"
 optional = false
@@ -626,8 +626,8 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf"},
-    {file = "beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"},
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
@@ -1004,8 +1004,8 @@ selenium = [
     {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
 ]
 soupsieve = [
-    {file = "soupsieve-2.3.1-py3-none-any.whl", hash = "sha256:1a3cca2617c6b38c0343ed661b1fa5de5637f257d4fe22bd9f1338010a1efefb"},
-    {file = "soupsieve-2.3.1.tar.gz", hash = "sha256:b8d49b1cd4f037c7082a9683dfa1801aa2597fb11c3a1155b7a5b94829b4f1f9"},
+    {file = "soupsieve-2.3.2-py3-none-any.whl", hash = "sha256:a714129d3021ec17ce5be346b1007300558b378332c289a1a20e7d4de6ff18a5"},
+    {file = "soupsieve-2.3.2.tar.gz", hash = "sha256:0bcc6d7432153063e3df09c3ac9442af3eba488715bfcad6a4c38ccb2a523124"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "7.0.2"
+version = "7.1.0"
 description = "Core utilities used by RPA Framework"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "7.0.1"
+version = "7.0.2"
 description = "Core utilities used by RPA Framework"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",

--- a/packages/core/src/RPA/core/windows/inspect.py
+++ b/packages/core/src/RPA/core/windows/inspect.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional, Union
 
 from RPA.core.windows.helpers import IS_WINDOWS, is_numeric
+from RPA.core.windows.locators import MatchObject
 
 if IS_WINDOWS:
     import uiautomation as auto
@@ -18,7 +19,7 @@ class ElementInspector:
         control_window: bool = True,
         recording: Optional[List["RecordElement"]] = None,
         verbose: bool = False,
-    ):
+    ) -> List[str]:
         """Inspect Windows element under mouse pointer.
 
         :param action: Action attached to the locator.
@@ -74,7 +75,9 @@ class ElementInspector:
         return output
 
     @staticmethod
-    def _get_element_key_properties(element, *, verbose: bool, regex_limit: int = 300):
+    def _get_element_key_properties(
+        element, *, verbose: bool, regex_limit: int = 300
+    ) -> Optional[str]:
         if not element:
             print("Got null element!")
             return None
@@ -90,7 +93,8 @@ class ElementInspector:
                 name_property = "regex:"
                 name = name[:regex_limit].strip()
             if " " in name:
-                name = f"'{name}'"
+                q = MatchObject.QUOTE
+                name = f"{q}{name}{q}"
             locators.append(f"{name_property}{name}")
         if automation_id and not is_numeric(automation_id):
             locators.append(f"id:{automation_id}")

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -170,7 +170,7 @@ class MatchObject:
             default_values.append(part_text)
 
     def add_locator(self, control_strategy: str, value: str, level: int = 0) -> None:
-        value = value.replace(self._Q, "").strip()
+        value = value.strip(f"{self._Q} ")
         if not value:
             return
 

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -169,9 +169,7 @@ class MatchObject:
             )
             default_values.append(part_text)
 
-    def add_locator(
-        self, control_strategy: str, value: Union[str, int], level: int = 0
-    ) -> None:
+    def add_locator(self, control_strategy: str, value: str, level: int = 0) -> None:
         value = value.replace(self._Q, "").strip()
         if not value:
             return
@@ -184,9 +182,9 @@ class MatchObject:
             value = value if value.endswith("Control") else f"{value}Control"
         elif control_strategy == "ClassName":
             self._classes.add(value.lower())  # pylint: disable=no-member
-        self.locators.append(
+        self.locators.append(  # pylint: disable=no-member
             (control_strategy, value, level)
-        )  # pylint: disable=no-member
+        )
 
     @property
     def classes(self) -> List[str]:

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -129,7 +129,7 @@ class MatchObject:
                 match_object.handle_locator_part(
                     level, part.group().strip(), default_values
                 )
-            if len(default_values) > 0:
+            if default_values:
                 match_object.add_locator("Name", " ".join(default_values), level=level)
         if not match_object.locators:
             match_object.add_locator("Name", locator)
@@ -159,7 +159,7 @@ class MatchObject:
 
         control_strategy = self._WINDOWS_LOCATOR_STRATEGIES.get(strategy)
         if control_strategy:
-            if len(default_values) > 0:
+            if default_values:
                 add_locator("Name", " ".join(default_values))
                 default_values.clear()
             add_locator(control_strategy, value)

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -1,7 +1,7 @@
 import functools
 import re
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from RPA.core.locators import LocatorsDatabase, WindowsLocator
 from RPA.core.vendor.deco import keyword as method
@@ -111,7 +111,7 @@ class MatchObject:
     _LOCATOR_REGEX = re.compile(
         rf"({':|'.join(_WINDOWS_LOCATOR_STRATEGIES)}:|or|and|desktop)"
         r"('{{1}}(.+)'{{1}})|(\S+)?",
-        re.IGNORECASE
+        re.IGNORECASE,
     )
 
     match_type: str = field(default="all")
@@ -201,74 +201,64 @@ class LocatorMethods(WindowsContext):
         self._locators_path = locators_path
         super().__init__(ctx)
 
-    def _get_element_with_locator_part(
-        self, locator, search_depth, root_element
+    @staticmethod
+    def _get_control_from_params(
+        search_params: Dict[str, str], root_control: Optional["Control"] = None
     ) -> "Control":
-        match_object = MatchObject()
-        mo = match_object.parse_locator(locator)
-        self.logger.info("locator '%s' to match element: %s", locator, mo)
-        search_params = {}
-        for loc in mo.locators:  # pylint: disable=not-an-iterable
-            search_params[loc[0]] = loc[1]
         offset = search_params.pop("offset", None)
+        control_type = search_params.pop("ControlType", "Control")
+        ElementControl = getattr(root_control, control_type, Control)
+        element = ElementControl(**search_params)
+        new_element = Control.CreateControlFromControl(element)
+        new_element.robocorp_click_offset = offset
+        return new_element
+
+    def _get_control_from_listed_windows(
+        self, search_params: Dict[str, str], *, param_type: str, win_type: str
+    ) -> "Control":
+        win_value = search_params.pop(param_type)
+        window_list = self.ctx.list_windows()
+        matches = [win for win in window_list if win[win_type] == win_value]
+        if not matches:
+            raise WindowControlError(
+                f"Could not locate window with {param_type} {win_value!r}"
+            )
+        elif len(matches) > 1:
+            raise WindowControlError(
+                f"Found more than one window with {param_type} {win_value!r}"
+            )
+        self.logger.info("Found process with window title: %r", matches[0]["title"])
+        search_params["Name"] = matches[0]["title"]
+        return self._get_control_from_params(search_params)
+
+    def _get_control_with_locator_part(
+        self, locator: str, search_depth: int, root_control: "Control"
+    ) -> "Control":
+        # Prepare control search parameters.
+        match_object = MatchObject.parse_locator(locator)
+        self.logger.info("Locator %r produced matcher: %s", locator, match_object)
+        search_params = {}
+        for loc in match_object.locators:  # pylint: disable=not-an-iterable
+            search_params[loc[0]] = loc[1]
         if "searchDepth" not in search_params:
             search_params["searchDepth"] = search_depth
 
+        # Obtain an element with the search parameters.
+        if "desktop" in search_params:
+            root_control = auto.GetRootControl()
+            return Control.CreateControlFromControl(root_control)
+
         if "executable" in search_params:
-            search_params.pop("ControlType")
-            executable = search_params.pop("executable")
-            window_list = self.ctx.list_windows()
-            matches = [w for w in window_list if w["name"] == executable]
-            if not matches:
-                raise WindowControlError(
-                    "Could not locate window with executable '%s'" % executable
-                )
-            elif len(matches) > 1:
-                raise WindowControlError(
-                    "Found more than one window with executable '%s'" % executable
-                )
-            self.logger.info(
-                "Found process with window title: '%s'", matches[0]["title"]
+            return self._get_control_from_listed_windows(
+                search_params, param_type="executable", win_type="name"
             )
-            search_params["Name"] = matches[0]["title"]
-            element = Control(**search_params)
-            new_element = Control.CreateControlFromControl(element)
-            new_element.robocorp_click_offset = offset
-            return new_element
 
         if "handle" in search_params:
-            search_params.pop("ControlType")
-            handle = search_params.pop("handle")
-            window_list = self.ctx.list_windows()
-            matches = [w for w in window_list if w["handle"] == handle]
-            if not matches:
-                raise WindowControlError(
-                    "Could not locate window with handle '%s'" % handle
-                )
-            elif len(matches) > 1:
-                raise WindowControlError(
-                    "Found more than one window with handle '%s'" % handle
-                )
-            self.logger.info(
-                "Found process with window title: '%s'", matches[0]["title"]
+            return self._get_control_from_listed_windows(
+                search_params, param_type="handle", win_type="handle"
             )
-            search_params["Name"] = matches[0]["title"]
-            element = Control(**search_params)
-            new_element = Control.CreateControlFromControl(element)
-            new_element.robocorp_click_offset = offset
-            return new_element
 
-        if "desktop" in search_params:
-            root_element = auto.GetRootControl()
-            search_params.pop("desktop")
-            return Control.CreateControlFromControl(root_element)
-
-        control_type = search_params.pop("ControlType", "Control")
-        element = getattr(root_element, control_type)
-        new_element = element(**search_params)
-        new_element = Control.CreateControlFromControl(new_element)
-        new_element.robocorp_click_offset = offset
-        return new_element
+        return self._get_control_from_params(search_params, root_control=root_control)
 
     def _load_by_alias(self, criteria: str) -> str:
         try:
@@ -276,10 +266,37 @@ class LocatorMethods(WindowsContext):
             if isinstance(locator, WindowsLocator):
                 return locator.value
         except ValueError:
-            # How to check if locator check should be done as inspector
-            # locators are just strings?
             pass
+
         return criteria
+
+    def _get_element_by_locator_string(
+        self, locator: str, search_depth: int, root_element: Optional[WindowsElement]
+    ) -> WindowsElement:
+        root = root_element.item if self._window_or_none(root_element) else None
+        anchor = self.anchor.item if self.anchor else None
+        window = self.window.item if self.window else None
+        self.logger.debug("argument root = %s", root)
+        self.logger.debug("active anchor = %s", anchor)
+        self.logger.debug("active window = %s", window)
+        root_result = root or anchor or window or auto.GetRootControl()
+        self.logger.debug("resulting root = %s", root_result)
+
+        control = None
+        locators = locator.split(" > ")
+        try:
+            for loc in locators:
+                self.logger.info("Root element: %r", root_result)
+                control = self._get_control_with_locator_part(
+                    loc, search_depth, root_result
+                )
+                root_result = control
+        except LookupError as err:
+            raise ElementNotFound(
+                f"Element not found with locator {locator!r}"
+            ) from err
+
+        return WindowsElement(control, locator)
 
     @method
     @with_timeout
@@ -306,30 +323,6 @@ class LocatorMethods(WindowsContext):
         else:
             element = locator
         if self._window_or_none(element) is None:
-            raise ElementNotFound(f"Unable to get element with '{locator}'")
+            raise ElementNotFound(f"Unable to get element with {locator!r}")
         self.logger.info("Returning element: %s", element)
         return element
-
-    def _get_element_by_locator_string(self, locator, search_depth, root_element):
-        root = root_element.item if self._window_or_none(root_element) else None
-        anchor = self.anchor.item if self.anchor else None
-        window = self.window.item if self.window else None
-        self.logger.debug("argument root = %s", root)
-        self.logger.debug("active anchor = %s", anchor)
-        self.logger.debug("active window = %s", window)
-        root_result = root or anchor or window or auto.GetRootControl()
-        self.logger.debug("resulting root = %s", root_result)
-        element = None
-
-        locators = locator.split(" > ")
-        try:
-            for loc in locators:
-                self.logger.info("Root element: '%s'", root_result)
-                element = self._get_element_with_locator_part(
-                    loc, search_depth, root_result
-                )
-                root_result = element
-        except LookupError as err:
-            raise ElementNotFound(f"Element not found with locator {locator}") from err
-
-        return WindowsElement(element, locator)

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -111,8 +111,8 @@ class MatchObject:
         "executable": "executable",
     }
     TREE_SEP = " > "
-    _Q = '"'  # enclosing quote character
-    _LOCATOR_REGEX = re.compile(rf"\S*{_Q}[^{_Q}]+{_Q}|\S+", re.IGNORECASE)
+    QUOTE = '"'  # enclosing quote character
+    _LOCATOR_REGEX = re.compile(rf"\S*{QUOTE}[^{QUOTE}]+{QUOTE}|\S+", re.IGNORECASE)
     _LOGGER = logging.getLogger(__name__)
 
     locators: List[Tuple] = field(default_factory=list)
@@ -170,7 +170,7 @@ class MatchObject:
             default_values.append(part_text)
 
     def add_locator(self, control_strategy: str, value: str, level: int = 0) -> None:
-        value = value.strip(f"{self._Q} ")
+        value = value.strip(f"{self.QUOTE} ")
         if not value:
             return
 

--- a/packages/core/src/RPA/core/windows/window.py
+++ b/packages/core/src/RPA/core/windows/window.py
@@ -23,12 +23,12 @@ class WindowMethods(WindowsContext):
 
     @staticmethod
     def get_icon(
-        filepath: str, icon_save_directory: Optional[str] = None
+        filepath: Optional[str], icon_save_directory: Optional[str] = None
     ) -> Optional[str]:
         if not filepath:
-            return None  # no file path to save the icon into
+            return None  # no file path to save the icon from
 
-        # TODO. Get different size icons
+        # TODO: Get icons of different sizes.
         small, large = win32gui.ExtractIconEx(filepath, 0, 10)
         if len(large) <= 0:
             return None  # no icon to extract
@@ -74,17 +74,29 @@ class WindowMethods(WindowsContext):
                 )
                 fullpath = win32process.GetModuleFileNameEx(handle, 0)
             except Exception as err:  # pylint: disable=broad-except
-                self.logger.info("Open process error in `List Windows`: %s", str(err))
+                self.logger.info("Open process error in `List Windows`: %s", err)
+            handle = win.NativeWindowHandle
             icon_string = (
                 self.get_icon(fullpath, icon_save_directory) if icons else None
+            )
+            rect = win.BoundingRectangle
+            rectangle = (
+                [rect.left, rect.top, rect.right, rect.bottom] if rect else [None] * 4
             )
             info = {
                 "title": win.Name,
                 "pid": pid,
                 "name": process_list[pid] if pid in process_list else None,
                 "path": fullpath,
-                "handle": win.NativeWindowHandle,
+                "handle": handle,
                 "icon": icon_string,
+                "automation_id": win.AutomationId,
+                "control_type": win.ControlTypeName,
+                "class_name": win.ClassName,
+                "rectangle": rectangle,
+                "keyboard_focus": win.HasKeyboardFocus,
+                "is_active": handle == auto.GetForegroundWindow(),
+                "object": win,
             }
             if icons and not icon_string:
                 self.logger.info("Icon for %s returned empty", win.Name)

--- a/packages/core/tests/test_locators.py
+++ b/packages/core/tests/test_locators.py
@@ -18,9 +18,6 @@ from RPA.core.locators import (
     BrowserLocator,
     ImageLocator,
     Coordinates,
-    Offset,
-    BrowserDOM,
-    ImageTemplate,
     sanitize_name,
     literal,
 )

--- a/packages/core/tests/test_windows.py
+++ b/packages/core/tests/test_windows.py
@@ -1,0 +1,82 @@
+import pytest
+from RPA.core.windows.locators import MatchObject
+
+
+@pytest.mark.parametrize(
+    "locator, locators",
+    [
+        ("Robocorp", [("Name", "Robocorp", 0)]),
+        ("Robocorp Window", [("Name", "Robocorp Window", 0)]),
+        ("name:Robocorp Window", [("Name", "Robocorp", 0), ("Name", "Window", 0)]),
+        ('name:"Robocorp Window"', [("Name", "Robocorp Window", 0)]),
+        ('name:"Robocorp\'s Window"', [("Name", "Robocorp's Window", 0)]),
+        (
+            'name:"Robocorp\'s Window" class:"My Class"',
+            [("Name", "Robocorp's Window", 0), ("ClassName", "My Class", 0)],
+        ),
+        (
+            "Robocorp > File",
+            [("Name", "Robocorp", 0), ("Name", "File", 1)],
+        ),  # this isn't currently used in end-to-end logic
+        (
+            '"Robocorp Window93" subname:Robocorp and class:"My Class" Test regex:Robo.+',
+            [
+                ("Name", "Robocorp Window93", 0),
+                ("SubName", "Robocorp", 0),
+                ("ClassName", "My Class", 0),
+                ("Name", "Test", 0),
+                ("RegexName", "Robo.+", 0),
+            ],
+        ),
+        ("Robocorp:Window", [("Name", "Robocorp:Window", 0)]),
+        ("name:Robocorp:Window", [("Name", "Robocorp:Window", 0)]),
+        (
+            "Robocorp:Window class:Class",
+            [("Name", "Robocorp:Window", 0), ("ClassName", "Class", 0)],
+        ),
+        (
+            "Robocorp'Window Test1 class:Class classx:Classx Test2",
+            [
+                ("Name", "Robocorp'Window Test1", 0),
+                ("ClassName", "Class", 0),
+                ("Name", "classx:Classx Test2", 0),
+            ],
+        ),
+        ("'Robocorp Window'", [("Name", "'Robocorp Window'", 0)]),
+        (
+            "name:'Robocorp Window'",
+            [("Name", "'Robocorp", 0), ("Name", "Window'", 0)],
+        ),  # single quotes don't work for enclosing, use double
+        ('Robocorp" Window', [("Name", 'Robocorp" Window', 0)]),
+        (
+            'name:Robocorp" Window class:"My Class"',
+            [("Name", 'Robocorp" Window class:', 0), ("Name", "My Class", 0)],
+        ),  # enclosing quotes have to be closed properly
+        (
+            'name:"Robocorp" Window" class:"My Class"',
+            [("Name", 'Robocorp" Window', 0), ("ClassName", "My Class", 0)],
+        ),  # lucky capture
+        (
+            'name:"Robocorp " Window" class:"My Class"',
+            [("Name", "Robocorp", 0), ("Name", 'Window" class:" My Class', 0)],
+        ),  # can't capture same quote in enclosing ones
+        ("", []),
+        (
+            "Robo and Corp or Window desktop",
+            [("desktop", "desktop", 0), ("Name", "Robo Corp Window", 0)],
+        ),
+        (
+            "id:123-456 depth:10 subname:Robo offset:100 executable:my.exe",
+            [
+                ("AutomationId", "123-456", 0),
+                ("searchDepth", 10, 0),
+                ("SubName", "Robo", 0),
+                ("offset", "100", 0),
+                ("executable", "my.exe", 0),
+            ],
+        ),
+    ],
+)
+def test_match_object(locator, locators):
+    match_object = MatchObject.parse_locator(locator)
+    assert match_object.locators == locators

--- a/packages/core/tests/test_windows.py
+++ b/packages/core/tests/test_windows.py
@@ -75,6 +75,15 @@ from RPA.core.windows.locators import MatchObject
                 ("executable", "my.exe", 0),
             ],
         ),
+        (
+            'type:Group and name:"Number pad" > type:Button and index:4',
+            [
+                ("ControlType", "GroupControl", 0),
+                ("Name", "Number pad", 0),
+                ("ControlType", "ButtonControl", 1),
+                ("foundIndex", 4, 1),
+            ],
+        ),
     ],
 )
 def test_match_object(locator, locators):


### PR DESCRIPTION
Since we use single quotes (`'`) for capturing windows locator names containing spaces, it's impossible currently to match windows with titles containing this character.

A fix would be to switch to double quotes (`'` -> `"`) and if we still want to match double quotes, then we can escape it like so:
- `name:"Robocorp Window"`
- `name:"Robocorp's Window"`
- `name:"Robocorp's \"W\"indow"` -> should match `Robocorp's "W"indow` but that's not possible as the regex stops at first `"` met after opening initially the `"`, otherwise we can't tackle cases like `name:"Robocorp's Window" class:"My Class"` (@mikahanninen I'm open to suggestions here if it doesn't look good -- check [unit-test](https://github.com/robocorp/rpaframework/pull/467/files#diff-9829d7d20e92624dd5bc0aa66be29d31c17170d0ca5a83de7d4bd4c197014540R55-R62) for more info)

### ToDo
- [x] Fix regex as it doesn't catch multiple quoted values like: `'Robocorp Window23' subname:Robocorp and class:'My Class' regex:Robo.+`
- [x] Replace single quote with double quote.
- [x] Unit-tests in core with such cases.
- [x] Real Windows tests based on this core pre-release.
- [x] Check and fix the recorder.

### Notes
- Taking care of #408 as well here in order to release **core** once.
- This is a breaking change for robots using `'` for enclosing locators (should refactor into `"`), but will be released into `windows` **3.1.0** as being part of `main` **13.3.0** since the keyword functionality remains the same, you just need to do this tiny change to your locator (if such single quotes are present in your robot).