### PR TITLE
Create extended JSON examples

### DIFF
--- a/packages/main/src/RPA/JSON.py
+++ b/packages/main/src/RPA/JSON.py
@@ -110,10 +110,11 @@ class JSON:
     Element  Description
     ======== ===========
     $        Root object/element
-    @        Current object/element
+    @        Current object/element inside expressions
     \. or [] Child operator
     \.\.     Recursive descent
     \*       Wilcard, any element
+    ,        Select multiple fields
     [n]      Array index
     [a:b:c]  Array slice (start, end, step)
     [a,b]    Union of indices or names
@@ -176,7 +177,7 @@ class JSON:
         :param indent: if given this value is used for json file indent
         :param encoding: file character encoding
 
-        Example:
+        Robot Framework Example:
 
         .. code:: robotframework
 
@@ -187,6 +188,16 @@ class JSON:
            # Save string to file
            ${mark}=    Set variable    {"name": "Mark", "mail": "mark@example.com"}
            Save JSON to file    ${mark}    mark.json
+
+        Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Save dictionary to file.
+            john = {"name": "John", "mail": "john@example.com"}
+            JSON().save_json_to_file(john, "john.json")
 
         """
         self.logger.info("Saving JSON to file: %s", filename)
@@ -204,13 +215,24 @@ class JSON:
         :param doc: JSON serializable object
         :return: string of the JSON serializable object
 
-        Example:
+        Robot Framework Example:
 
         .. code:: robotframework
 
            ${obj}=    Create dictionary    Key=Value
            ${json}=   Convert JSON to string    ${obj}
            Should be equal    ${json}     {"Key": "Value"}
+
+        Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+            from robot.libraries.BuiltIn import BuiltIn
+
+            obj = {"Key": "Value"}
+            json = JSON().convert_json_to_string(obj)
+            BuiltIn().should_be_equal(json, '{"Key": "Value"}')
 
         """
         return json.dumps(doc)
@@ -222,13 +244,24 @@ class JSON:
         :param doc: JSON string
         :return: JSON serializable object of the string
 
-        Example:
+        Robot Framework Example:
 
         .. code:: robotframework
 
            ${json}=    Set variable    {"Key": "Value"}
            &{obj}=     Convert string to JSON    ${json}
            Should be equal    ${obj.Key}    Value
+
+        Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+            from robot.libraries.BuiltIn import BuiltIn
+
+            json = '{"Key": "Value"}'
+            obj = JSON().convert_string_to_json(json)
+            BuiltIn().should_be_equal(obj["Key"], "Value")
 
         """
         return json.loads(doc)
@@ -245,7 +278,7 @@ class JSON:
         :param value: values to either append or update
         :return: JSON serializable object of the updated JSON
 
-        Example:
+        Robot Framework Example:
 
         .. code:: robotframework
 
@@ -253,6 +286,20 @@ class JSON:
            &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
            &{person}=    Create dictionary      Name=John
            &{after}=     Add to JSON    ${before}   $.People    ${person}
+
+        Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Change the name value for all people
+            js = JSON()
+            before = js.convert_string_to_json('{"People": [{"Name": "Mark"}, {"Name": "Jane"}]}')
+            person = {"Name": "John"}
+            after = js.add_to_json(before, "$.People", person)
+
+            print(after)
 
         """  # noqa: E501
         self.logger.info('Add to JSON with expression: "%s"', expr)
@@ -278,7 +325,7 @@ class JSON:
         :return: string containg the match OR None if no matches
         :raises ValueError: if more than one match
 
-        Example:
+        Simple Robot Framework Example:
 
         .. code:: robotframework
 
@@ -286,7 +333,115 @@ class JSON:
            &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
            ${first}=     Get value from JSON      ${people}   $.People[0].Name
 
+        Simple Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Get the name value for the second person.
+            people = {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+            second = JSON().get_value_from_json(people, "$.People[1].Name")
+            print(second)
+
+        Extended Robot Framework Example:
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Library         RPA.JSON
+            Suite Setup     Ingest JSON
+
+            *** Variables ***
+            ${JSON_STRING}      {
+            ...                   "clients": [
+            ...                     {
+            ...                       "name": "Johnny Example",
+            ...                       "email": "john@example.com",
+            ...                       "orders": [
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 103.20, "id":"guid-001"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 98.99, "id":"guid-002"}
+            ...                       ]
+            ...                     },
+            ...                     {
+            ...                       "name": "Jane Example",
+            ...                       "email": "jane@example.com",
+            ...                       "orders": [
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 22.00, "id":"guid-003"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 2330.01, "id":"guid-004"},
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 152.12, "id":"guid-005"}
+            ...                       ]
+            ...                     }
+            ...                   ]
+            ...                 }
+            ${ID}               guid-003
+
+            *** Tasks ***
+            Get email for specific order id
+                ${email}=    Get value from json    ${JSON_DOC}    $.clients[?(@..id=="${ID}")].email
+                Log    \nOUTPUT IS\n ${email}    console=${True}
+
+            Get All Prices and Order Ids
+                # Arithmetic operations only work when lists are of equal lengths and types.
+                ${prices}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[*].orders[*].id + " has price " + $.clients[*].orders[*].price.`str()`
+                Log    \nOUTPUT IS\n ${prices}    console=${True}
+
+            Find Only Valid Emails With Regex
+                # The regex used in this example is simplistic and
+                # will not work with all email addresses
+                ${emails}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[?(@.email =~ "[a-zA-Z]+@[a-zA-Z]+\\.[a-zA-Z]+")].email
+                Log    \nOUTPUT IS\n ${emails}    console=${True}
+
+            Find Orders From Texas Over 100
+                # The regex used in this example is simplistic and
+                # will not work with all email addresses
+                ${orders}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[*].orders[?(@.price > 100 & @.state == "TX")]
+                Log    \nOUTPUT IS\n ${orders}    console=${True}
+
+            *** Keywords ***
+            Ingest JSON
+                ${doc}=    Convert string to json    ${JSON_STRING}
+                Set suite variable    ${JSON_DOC}    ${doc}
+
+        The above code produces the following console output:
+
+        .. code::
+
+            ==============================================================================
+            Json Ext Get Value Example
+            ==============================================================================
+            Get email for specific order id
+            OUTPUT IS
+            jane@example.com
+            | PASS |
+            ------------------------------------------------------------------------------
+            Get All Prices and Order Ids
+            OUTPUT IS
+            ['guid-001 has price 103.2', 'guid-002 has price 98.99', 'guid-003 has price 22.0', 'guid-004 has price 2330.01', 'guid-005 has price 152.12']
+            | PASS |
+            ------------------------------------------------------------------------------
+            Find Only Valid Emails With Regex
+            OUTPUT IS
+            ['john@example.com', 'jane@example.com']
+            | PASS |
+            ------------------------------------------------------------------------------
+            Find Orders From Texas Over 100
+            OUTPUT IS
+            [{'address': 'Streetroad 123', 'state': 'TX', 'price': 103.2, 'id': 'guid-001'}, {'address': 'Streetroad 123', 'state': 'TX', 'price': 2330.01, 'id': 'guid-004'}]
+            | PASS |
+            ------------------------------------------------------------------------------
+            Json Ext Get Value Example                                            | PASS |
+            4 tests, 4 passed, 0 failed
+            ==============================================================================
+
         """  # noqa: E501
+        # TODO: Docstring includes examples for get value and get values.
         self.logger.info('Get value from JSON with expression: "%s"', expr)
         result = [match.value for match in parse(expr).find(doc)]
         if len(result) == 0:

--- a/packages/main/src/RPA/JSON.py
+++ b/packages/main/src/RPA/JSON.py
@@ -380,68 +380,14 @@ class JSON:
             Get email for specific order id
                 ${email}=    Get value from json    ${JSON_DOC}    $.clients[?(@..id=="${ID}")].email
                 Log    \nOUTPUT IS\n ${email}    console=${True}
-
-            Get All Prices and Order Ids
-                # Arithmetic operations only work when lists are of equal lengths and types.
-                ${prices}=    Get values from json
-                ...    ${JSON_DOC}
-                ...    $.clients[*].orders[*].id + " has price " + $.clients[*].orders[*].price.`str()`
-                Log    \nOUTPUT IS\n ${prices}    console=${True}
-
-            Find Only Valid Emails With Regex
-                # The regex used in this example is simplistic and
-                # will not work with all email addresses
-                ${emails}=    Get values from json
-                ...    ${JSON_DOC}
-                ...    $.clients[?(@.email =~ "[a-zA-Z]+@[a-zA-Z]+\\.[a-zA-Z]+")].email
-                Log    \nOUTPUT IS\n ${emails}    console=${True}
-
-            Find Orders From Texas Over 100
-                # The regex used in this example is simplistic and
-                # will not work with all email addresses
-                ${orders}=    Get values from json
-                ...    ${JSON_DOC}
-                ...    $.clients[*].orders[?(@.price > 100 & @.state == "TX")]
-                Log    \nOUTPUT IS\n ${orders}    console=${True}
+                Should be equal as strings    ${email}    jane@example.com
 
             *** Keywords ***
             Ingest JSON
                 ${doc}=    Convert string to json    ${JSON_STRING}
                 Set suite variable    ${JSON_DOC}    ${doc}
 
-        The above code produces the following console output:
-
-        .. code::
-
-            ==============================================================================
-            Json Ext Get Value Example
-            ==============================================================================
-            Get email for specific order id
-            OUTPUT IS
-            jane@example.com
-            | PASS |
-            ------------------------------------------------------------------------------
-            Get All Prices and Order Ids
-            OUTPUT IS
-            ['guid-001 has price 103.2', 'guid-002 has price 98.99', 'guid-003 has price 22.0', 'guid-004 has price 2330.01', 'guid-005 has price 152.12']
-            | PASS |
-            ------------------------------------------------------------------------------
-            Find Only Valid Emails With Regex
-            OUTPUT IS
-            ['john@example.com', 'jane@example.com']
-            | PASS |
-            ------------------------------------------------------------------------------
-            Find Orders From Texas Over 100
-            OUTPUT IS
-            [{'address': 'Streetroad 123', 'state': 'TX', 'price': 103.2, 'id': 'guid-001'}, {'address': 'Streetroad 123', 'state': 'TX', 'price': 2330.01, 'id': 'guid-004'}]
-            | PASS |
-            ------------------------------------------------------------------------------
-            Json Ext Get Value Example                                            | PASS |
-            4 tests, 4 passed, 0 failed
-            ==============================================================================
-
         """  # noqa: E501
-        # TODO: Docstring includes examples for get value and get values.
         self.logger.info('Get value from JSON with expression: "%s"', expr)
         result = [match.value for match in parse(expr).find(doc)]
         if len(result) == 0:
@@ -463,13 +409,91 @@ class JSON:
         :param expr: JSONPath expression
         :return: list of values that match
 
-        Example:
+        Simple Robot Framework Example:
 
         .. code:: robotframework
 
            # Get all the names for all people
            &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
            @{names}=     Get values from JSON     ${people}   $.People[*].Name
+
+        Simple Python Example:
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Get all the names for all people
+            people = {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+            names = JSON().get_values_from_json(people, "$.People[*].Name")
+            print(second)
+
+        Extended Robot Framework Example:
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Library         RPA.JSON
+            Suite Setup     Ingest JSON
+
+            *** Variables ***
+            ${JSON_STRING}      {
+            ...                   "clients": [
+            ...                     {
+            ...                       "name": "Johnny Example",
+            ...                       "email": "john@example.com",
+            ...                       "orders": [
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 103.20, "id":"guid-001"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 98.99, "id":"guid-002"}
+            ...                       ]
+            ...                     },
+            ...                     {
+            ...                       "name": "Jane Example",
+            ...                       "email": "jane@example.com",
+            ...                       "orders": [
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 22.00, "id":"guid-003"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 2330.01, "id":"guid-004"},
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 152.12, "id":"guid-005"}
+            ...                       ]
+            ...                     }
+            ...                   ]
+            ...                 }
+            ${ID}               guid-003
+
+            *** Tasks ***
+            Get All Prices and Order Ids
+                # Arithmetic operations only work when lists are of equal lengths and types.
+                ${prices}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[*].orders[*].id + " has price " + $.clients[*].orders[*].price.`str()`
+                Log    \nOUTPUT IS\n ${prices}    console=${True}
+                Should be equal as strings    ${prices}
+                ...    ['guid-001 has price 103.2', 'guid-002 has price 98.99', 'guid-003 has price 22.0', 'guid-004 has price 2330.01', 'guid-005 has price 152.12']
+
+            Find Only Valid Emails With Regex
+                # The regex used in this example is simplistic and
+                # will not work with all email addresses
+                ${emails}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[?(@.email =~ "[a-zA-Z]+@[a-zA-Z]+\\.[a-zA-Z]+")].email
+                Log    \nOUTPUT IS\n ${emails}    console=${True}
+                Should be equal as strings    ${emails}    ['john@example.com', 'jane@example.com']
+
+            Find Orders From Texas Over 100
+                # The regex used in this example is simplistic and
+                # will not work with all email addresses
+                ${orders}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[*].orders[?(@.price > 100 & @.state == "TX")]
+                Log    \nOUTPUT IS\n ${orders}    console=${True}
+                Should be equal as strings    ${orders}
+                ...    [{'address': 'Streetroad 123', 'state': 'TX', 'price': 103.2, 'id': 'guid-001'}, {'address': 'Streetroad 123', 'state': 'TX', 'price': 2330.01, 'id': 'guid-004'}]
+
+
+            *** Keywords ***
+            Ingest JSON
+                ${doc}=    Convert string to json    ${JSON_STRING}
+                Set suite variable    ${JSON_DOC}    ${doc}
 
         """  # noqa: E501
         self.logger.info('Get values from JSON with expression: "%s"', expr)

--- a/packages/main/src/RPA/JSON.py
+++ b/packages/main/src/RPA/JSON.py
@@ -20,7 +20,8 @@ class JSON:
 
     .. _JSON: http://json.org/
 
-    **Serialization**
+    Serialization
+    =============
 
     The term `serialization` refers to the process of converting
     Robot Framework or Python types to JSON or the other way around.
@@ -41,11 +42,13 @@ class JSON:
     null          None
     ============= =======
 
-    **About JSONPath**
+    About JSONPath
+    ==============
 
     Reading and writing values from/to JSON serializable objects is done
     using `JSONPath`_. It's a syntax designed to quickly and easily refer to
-    specific elements in a JSON structure.
+    specific elements in a JSON structure. The specific flavor used in this
+    library is based on `jsonpath-ng`_.
 
     Compared to Python's normal dictionary access, JSONPath expressions can
     target multiple elements through features such as conditionals and wildcards,
@@ -53,8 +56,10 @@ class JSON:
     for XML structures.
 
     .. _JSONPath: http://goessner.net/articles/JsonPath/
+    .. _jsonpath-ng: https://pypi.org/project/jsonpath-ng/#description
 
-    **Syntax example**
+    Syntax example
+    --------------
 
     For this example consider the following structure:
 
@@ -85,42 +90,104 @@ class JSON:
 
     .. code-block:: robotframework
 
-       # First order of first client, with direct dictionary access
-       ${value}=    Set variable    ${json}["clients"][0]["orders"][0]
+        *** Tasks ***
+        Nested access
+            # First order of first client, with direct dictionary access
+            ${value}=    Set variable    ${json}["clients"][0]["orders"][0]
 
-       # JSONPath access
-       ${value}=    Get value from JSON    ${json}    $.clients[0].orders[0]
+            # JSONPath access
+            ${value}=    Get value from JSON    ${json}    $.clients[0].orders[0]
 
     But the power comes from complicated expressions:
 
     .. code-block:: robotframework
 
-       # Find delivery addresses for all orders
-       ${prices}=        Get values from JSON    $..address
+        *** Tasks ***
+        Complicated expressions
+            # Find delivery addresses for all orders
+            ${prices}=        Get values from JSON    $..address
 
-       # Find orders that cost over 100
-       ${expensives}=    Get values from JSON    $..orders[?(@.price>100)]
+            # Find orders that cost over 100
+            ${expensives}=    Get values from JSON    $..orders[?(@.price>100)]
 
 
-    **Supported Expressions**
+    Supported Expressions
+    ---------------------
 
     The supported syntax elements are:
 
-    ======== ===========
-    Element  Description
-    ======== ===========
-    $        Root object/element
-    @        Current object/element inside expressions
-    \. or [] Child operator
-    \.\.     Recursive descent
-    \*       Wilcard, any element
-    ,        Select multiple fields
-    [n]      Array index
-    [a:b:c]  Array slice (start, end, step)
-    [a,b]    Union of indices or names
-    ?()      Apply a filter expression
-    ()       Script expression
-    ======== ===========
+    =======================    ===========
+    Element                    Description
+    =======================    ===========
+    ``$``                      Root object/element
+    ``@``                      Current object/element inside expressions
+    ``.`` or ``[]``            Child operator
+    ``..``                     Recursive descendant operator
+    ````parent````             Parent operator, see `functions`_
+    ``*``                      Wilcard, any element
+    ``,``                      Select multiple fields
+    ``[n]``                    Array index
+    ``[a:b:c]``                Array slice (start, end, step)
+    ``[a,b]``                  Union of indices or names
+    ``[?()]``                  Apply a filter expression
+    ``()``                     Script expression
+    ``[\\field]``              Sort descending by ``field``, cannot be combined with filters.
+    ``[/field]``               Sort ascending by ``field``, cannot be combined with filters.
+    ````str()````              Convert value to string, see `functions`_
+    ````sub()````              Regex substitution function, see `functions`_
+    ````len````                Calculate value's length, see `functions`_
+    ````split()````            String split function, see `functions`_
+    ``+`` ``-`` ``*`` ``/``    Arithmetic functions, see `functions`_
+    =======================    ===========
+
+    Functions
+    ^^^^^^^^^
+
+    This library allows JSON path expressions to include certain functions
+    which can provide additional benefit to users. These functions are
+    generally encapsulated in backticks (`````). Some functions require
+    you to pass arguments similar to a Python function.
+
+    For example, let's say a JSON has nodes on the JSON path
+    ``$.books[*].genres`` which are represented as strings of genres with
+    commas separating each genre. So for one book, this node might have a
+    value like ``horror,young-adult``. You can return a list of first genre
+    for each book by using the ``split`` function like so:
+
+    .. code-block:: robotframework
+
+        *** Task ***
+        Get genres
+            ${genres}=  Get values from JSON    $.books[*].genres.`split(,, 0, -1)`
+
+    Each functions parameters are defined here:
+
+    ===================================  =====
+    Function                             Usage
+    ===================================  =====
+    ``str()``                            No parameters, but parenthesis are required
+    ``sub(/regex/, repl)``               The regex pattern must be provided in *regex* and
+                                         the replacement value provided in *repl*
+    ``len``                              No parameters and no parenthesis
+    ``split(char, segment, max_split)``  Separator character provided as *char*, which
+                                         index from the resulting array to be returns
+                                         provided as *segment*, and maximum number of
+                                         splits to perform provided as *max_split*, ``-1``
+                                         for all splits.
+    ``parent``                           No parameters, no parenthesis
+    ===================================  =====
+
+    **Arithmetic Functions**
+
+    JSON Path can be written and combined to concatenate string values
+    or perform arithmetic functions on numerical values. Each JSONPath
+    expression used must return the same type, and when performing
+    such functions between returned lists, each list must be the same
+    length. An example is included in documentation for the keyword
+    \`Get values from JSON\`.
+
+    Additional Information
+    ^^^^^^^^^^^^^^^^^^^^^^
 
     There are a multitude of different script expressions
     in addition to the elements listed above, which can
@@ -153,8 +220,10 @@ class JSON:
 
         .. code:: robotframework
 
-           &{auth}=    Load JSON from file    auth.json
-           Log   Current auth token: ${auth.token}
+            *** Task ***
+            Load json
+                &{auth}=    Load JSON from file    auth.json
+                Log   Current auth token: ${auth.token}
 
         """
         self.logger.info("Loading JSON from file: %s", filename)
@@ -181,13 +250,14 @@ class JSON:
 
         .. code:: robotframework
 
-           # Save dictionary to file
-           ${john}=    Create dictionary    name=John    mail=john@example.com
-           Save JSON to file    ${john}    john.json
+            *** Tasks ***
+            Save dictionary to file
+                ${john}=    Create dictionary    name=John    mail=john@example.com
+                Save JSON to file    ${john}    john.json
 
-           # Save string to file
-           ${mark}=    Set variable    {"name": "Mark", "mail": "mark@example.com"}
-           Save JSON to file    ${mark}    mark.json
+            Save string to file
+                ${mark}=    Set variable    {"name": "Mark", "mail": "mark@example.com"}
+                Save JSON to file    ${mark}    mark.json
 
         Python Example:
 
@@ -219,9 +289,11 @@ class JSON:
 
         .. code:: robotframework
 
-           ${obj}=    Create dictionary    Key=Value
-           ${json}=   Convert JSON to string    ${obj}
-           Should be equal    ${json}     {"Key": "Value"}
+            *** Task ***
+            Convert to string
+                ${obj}=    Create dictionary    Key=Value
+                ${json}=   Convert JSON to string    ${obj}
+                Should be equal    ${json}     {"Key": "Value"}
 
         Python Example:
 
@@ -248,9 +320,11 @@ class JSON:
 
         .. code:: robotframework
 
-           ${json}=    Set variable    {"Key": "Value"}
-           &{obj}=     Convert string to JSON    ${json}
-           Should be equal    ${obj.Key}    Value
+            *** Task ***
+            Convert to json
+                ${json}=    Set variable    {"Key": "Value"}
+                &{obj}=     Convert string to JSON    ${json}
+                Should be equal    ${obj.Key}    Value
 
         Python Example:
 
@@ -282,10 +356,11 @@ class JSON:
 
         .. code:: robotframework
 
-           # Change the name value for all people
-           &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-           &{person}=    Create dictionary      Name=John
-           &{after}=     Add to JSON    ${before}   $.People    ${person}
+            *** Task ***
+            Change the name value for all people
+                &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+                &{person}=    Create dictionary      Name=John
+                &{after}=     Add to JSON    ${before}   $.People    ${person}
 
         Python Example:
 
@@ -325,15 +400,16 @@ class JSON:
         :return: string containg the match OR None if no matches
         :raises ValueError: if more than one match
 
-        Simple Robot Framework Example:
+        Short Robot Framework Example:
 
         .. code:: robotframework
 
-           # Get the name value for the first person
-           &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-           ${first}=     Get value from JSON      ${people}   $.People[0].Name
+            *** Task ***
+            Get the name value for the first person
+                &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+                ${first}=     Get value from JSON      ${people}   $.People[0].Name
 
-        Simple Python Example:
+        Short Python Example:
 
         .. code:: python
 
@@ -379,7 +455,7 @@ class JSON:
             *** Tasks ***
             Get email for specific order id
                 ${email}=    Get value from json    ${JSON_DOC}    $.clients[?(@..id=="${ID}")].email
-                Log    \nOUTPUT IS\n ${email}    console=${True}
+                Log    \\nOUTPUT IS\\n ${email}    console=${True}
                 Should be equal as strings    ${email}    jane@example.com
 
             *** Keywords ***
@@ -409,15 +485,16 @@ class JSON:
         :param expr: JSONPath expression
         :return: list of values that match
 
-        Simple Robot Framework Example:
+        Short Robot Framework Example:
 
         .. code:: robotframework
 
-           # Get all the names for all people
-           &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-           @{names}=     Get values from JSON     ${people}   $.People[*].Name
+            *** Task ***
+            Get all the names for all people
+                &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+                @{names}=     Get values from JSON     ${people}   $.People[*].Name
 
-        Simple Python Example:
+        Short Python Example:
 
         .. code:: python
 
@@ -466,7 +543,7 @@ class JSON:
                 ${prices}=    Get values from json
                 ...    ${JSON_DOC}
                 ...    $.clients[*].orders[*].id + " has price " + $.clients[*].orders[*].price.`str()`
-                Log    \nOUTPUT IS\n ${prices}    console=${True}
+                Log    \\nOUTPUT IS\\n ${prices}    console=${True}
                 Should be equal as strings    ${prices}
                 ...    ['guid-001 has price 103.2', 'guid-002 has price 98.99', 'guid-003 has price 22.0', 'guid-004 has price 2330.01', 'guid-005 has price 152.12']
 
@@ -476,7 +553,7 @@ class JSON:
                 ${emails}=    Get values from json
                 ...    ${JSON_DOC}
                 ...    $.clients[?(@.email =~ "[a-zA-Z]+@[a-zA-Z]+\\.[a-zA-Z]+")].email
-                Log    \nOUTPUT IS\n ${emails}    console=${True}
+                Log    \\nOUTPUT IS\\n ${emails}    console=${True}
                 Should be equal as strings    ${emails}    ['john@example.com', 'jane@example.com']
 
             Find Orders From Texas Over 100
@@ -485,7 +562,7 @@ class JSON:
                 ${orders}=    Get values from json
                 ...    ${JSON_DOC}
                 ...    $.clients[*].orders[?(@.price > 100 & @.state == "TX")]
-                Log    \nOUTPUT IS\n ${orders}    console=${True}
+                Log    \\nOUTPUT IS\\n ${orders}    console=${True}
                 Should be equal as strings    ${orders}
                 ...    [{'address': 'Streetroad 123', 'state': 'TX', 'price': 103.2, 'id': 'guid-001'}, {'address': 'Streetroad 123', 'state': 'TX', 'price': 2330.01, 'id': 'guid-004'}]
 
@@ -511,13 +588,85 @@ class JSON:
         :param value: New value for the matching item(s)
         :return: JSON serializable object with updated results
 
-        Example:
+        Short Robot Framework Example:
 
         .. code:: robotframework
 
-           # Change the name key for all people
-           &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-           &{after}=     Update value to JSON     ${before}   $.People[*].Name    JohnMalkovich
+            *** Task ***
+            Change the name key for all people
+                &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+                &{after}=     Update value to JSON     ${before}   $.People[*].Name    JohnMalkovich
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Change the name key for all people
+            before = {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+            after = JSON().update_value_to_json(before, "$.People[*].Name","JohnMalkovich")
+            print(after)
+
+        Extended Robot Framework Example:
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Library         RPA.JSON
+            Library    Collections
+            Suite Setup     Ingest JSON
+
+            *** Variables ***
+            ${JSON_STRING}      {
+            ...                   "clients": [
+            ...                     {
+            ...                       "name": "Johnny Example",
+            ...                       "email": "john@example.com",
+            ...                       "id": "user-001",
+            ...                       "orders": [
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 103.20, "id":"guid-001"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 98.99, "id":"guid-002"}
+            ...                       ]
+            ...                     },
+            ...                     {
+            ...                       "name": "Jane Example",
+            ...                       "email": "jane@example.com",
+            ...                       "id": "user-002",
+            ...                       "orders": [
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 22.00, "id":"guid-003"},
+            ...                         {"address": "Streetroad 123", "state": "TX", "price": 2330.01, "id":"guid-004"},
+            ...                         {"address": "Waypath 321", "state": "WA", "price": 152.12, "id":"guid-005"}
+            ...                       ]
+            ...                     }
+            ...                   ]
+            ...                 }
+            ${ID}               guid-003
+
+            *** Tasks ***
+            Update user email
+                ${updated_doc}=    Update value to json
+                ...    ${JSON_DOC}
+                ...    $.clients[?(@.id=="user-001")].email
+                ...    johnny@example.com
+                Log    \\nNEW JSON IS\\n ${updated_doc}    console=${True}
+                ${new_email}=    Get value from json    ${updated_doc}    $.clients[?(@.id=="user-001")].email
+                Should be equal as strings    ${new_email}    johnny@example.com
+
+            Add additional charge to all prices in WA
+                # This example also shows how the update keyword changes the original JSON doc in memory.
+                ${id_price}=    Get values from json
+                ...    ${JSON_DOC}
+                ...    $.clients[*].orders[?(@.state=="WA")].id,price
+                FOR    ${order_id}    ${price}    IN    @{id_price}
+                    Update value to json    ${JSON_DOC}    $.clients[*].orders[?(@.id=="${order_id}")].price    ${{${price} * 1.06}}
+                END
+                Log    \\nNEW JSON IS\\n ${JSON_DOC}    console=${True}
+                ${one_price}=    Get value from json    ${JSON_DOC}    $..orders[?(@.id==${ID})].price
+                Should be equal as numbers    ${one_price}    23.32
+
+            *** Keywords ***
+            Ingest JSON
+                ${doc}=    Convert string to json    ${JSON_STRING}
+                Set suite variable    ${JSON_DOC}    ${doc}
 
         """  # noqa: E501
         self.logger.info('Update JSON with expression: "%s"', expr)
@@ -542,9 +691,19 @@ class JSON:
 
         .. code:: robotframework
 
-           # Delete all people
-           &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-           &{after}=     Delete from JSON    ${before}   $.People[*]
+            *** Task ***
+            Delete all people
+                &{before}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+                &{after}=     Delete from JSON    ${before}   $.People[*]
+
+        .. code:: python
+
+            from RPA.JSON import JSON
+
+            # Delete all people
+            before = {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+            after = JSON().delete_from_json(before, "$.People[*]")
+            print(after)
 
         """  # noqa: E501
         self.logger.info('Delete from JSON with expression: "%s"', expr)

--- a/packages/main/src/RPA/JSON.py
+++ b/packages/main/src/RPA/JSON.py
@@ -131,8 +131,10 @@ class JSON:
     ``[a,b]``                  Union of indices or names
     ``[?()]``                  Apply a filter expression
     ``()``                     Script expression
-    ``[\\field]``              Sort descending by ``field``, cannot be combined with filters.
-    ``[/field]``               Sort ascending by ``field``, cannot be combined with filters.
+    ``[\\field]``              Sort descending by ``field``, cannot be combined with
+                               filters.
+    ``[/field]``               Sort ascending by ``field``, cannot be combined with
+                               filters.
     ````str()````              Convert value to string, see `functions`_
     ````sub()````              Regex substitution function, see `functions`_
     ````len````                Calculate value's length, see `functions`_
@@ -166,14 +168,14 @@ class JSON:
     Function                             Usage
     ===================================  =====
     ``str()``                            No parameters, but parenthesis are required
-    ``sub(/regex/, repl)``               The regex pattern must be provided in *regex* and
-                                         the replacement value provided in *repl*
+    ``sub(/regex/, repl)``               The regex pattern must be provided in *regex*
+                                         and the replacement value provided in *repl*
     ``len``                              No parameters and no parenthesis
     ``split(char, segment, max_split)``  Separator character provided as *char*, which
                                          index from the resulting array to be returns
                                          provided as *segment*, and maximum number of
-                                         splits to perform provided as *max_split*, ``-1``
-                                         for all splits.
+                                         splits to perform provided as *max_split*,
+                                         ``-1`` for all splits.
     ``parent``                           No parameters, no parenthesis
     ===================================  =====
 


### PR DESCRIPTION
* Update class docstring to use formatted headers.
* Add link to `jsonpath-ng` as underlying library because that project also has additional documentation on implementation (though it seems to be somewhat inaccurate in some respects).
* Update class docstring to describe named operators and functions.
* Create extended JSON path examples for `Get Value From JSON`, `Get Values From JSON`, and `Update Value To JSON`. Extended examples include the use of functions and filters in several ways, as well as how to utilize regex.