### PR TITLE
`RPA.Email.Exchange` Fix typing in library keywords

### DIFF
--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -893,15 +893,15 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.1"
+version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "pluggy"
@@ -1080,7 +1080,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pypdf2"
-version = "1.27.5"
+version = "1.27.7"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 category = "main"
 optional = false
@@ -2856,8 +2856,8 @@ pillow = [
     {file = "Pillow-8.4.0.tar.gz", hash = "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
-    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -2910,6 +2910,11 @@ psutil = [
     {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
     {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
     {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d"},
+    {file = "psutil-5.9.0-cp36-cp36m-win32.whl", hash = "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64"},
+    {file = "psutil-5.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94"},
     {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
@@ -2995,8 +3000,8 @@ pyparsing = [
     {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
 ]
 pypdf2 = [
-    {file = "PyPDF2-1.27.5-py3-none-any.whl", hash = "sha256:9c81fc06be50fbf2e6199e8c2eac05f3eaafae4b3905ecca41200f5b02ac43d7"},
-    {file = "PyPDF2-1.27.5.tar.gz", hash = "sha256:7c18c1d48e56547b1c33f772dc15d6adbd1f4020b62e64bb4a0bc0ee2ab94511"},
+    {file = "PyPDF2-1.27.7-py3-none-any.whl", hash = "sha256:51855f5df6f25b825f7bc8f63066819ef6c5654ac01c191ed657ee456153574b"},
+    {file = "PyPDF2-1.27.7.tar.gz", hash = "sha256:fd35f4e6bb8f050a809fec3eecb6c3603f5043584b57002f7c5b26660d6b16ce"},
 ]
 pyperclip = [
     {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},

--- a/packages/main/src/RPA/Email/Exchange.py
+++ b/packages/main/src/RPA/Email/Exchange.py
@@ -411,7 +411,9 @@ class Exchange:
                 if html:
                     body = body.replace(imname, f"cid:{imname}")
 
-    def create_folder(self, folder_name: str = None, parent_folder: str = None) -> bool:
+    def create_folder(
+        self, folder_name: Optional[str] = None, parent_folder: Optional[str] = None
+    ) -> bool:
         """Create email folder
 
         :param folder_name: name for the new folder
@@ -431,7 +433,9 @@ class Exchange:
         new_folder = Folder(parent=parent, name=folder_name)
         new_folder.save()
 
-    def delete_folder(self, folder_name: str = None, parent_folder: str = None) -> bool:
+    def delete_folder(
+        self, folder_name: Optional[str] = None, parent_folder: Optional[str] = None
+    ) -> bool:
         """Delete email folder
 
         :param folder_name: current folder name
@@ -451,7 +455,10 @@ class Exchange:
         folder_to_delete.delete()
 
     def rename_folder(
-        self, oldname: str = None, newname: str = None, parent_folder: str = None
+        self,
+        oldname: Optional[str] = None,
+        newname: Optional[str] = None,
+        parent_folder: Optional[str] = None,
     ) -> bool:
         """Rename email folder
 
@@ -480,9 +487,9 @@ class Exchange:
 
     def empty_folder(
         self,
-        folder_name: str = None,
-        parent_folder: str = None,
-        delete_sub_folders: bool = False,
+        folder_name: Optional[str] = None,
+        parent_folder: Optional[str] = None,
+        delete_sub_folders: Optional[bool] = False,
     ) -> bool:
         """Empty email folder of all items
 
@@ -502,10 +509,10 @@ class Exchange:
 
     def move_messages(
         self,
-        criterion: str = "",
-        source: str = None,
-        target: str = None,
-        contains: bool = False,  # pylint: disable=unused-argument
+        criterion: Optional[str] = "",
+        source: Optional[str] = None,
+        target: Optional[str] = None,
+        contains: Optional[bool] = False,  # pylint: disable=unused-argument
     ) -> bool:
         """Move message(s) from source folder to target folder
 
@@ -537,8 +544,8 @@ class Exchange:
 
     def move_message(
         self,
-        msg: dict,
-        target: str,
+        msg: Optional[dict],
+        target: Optional[str],
     ):
         """Move a message into target folder
 
@@ -682,11 +689,11 @@ class Exchange:
 
     def wait_for_message(
         self,
-        criterion: str = "",
-        timeout: float = 5.0,
-        interval: float = 1.0,
-        contains: bool = False,  # pylint: disable=unused-argument
-        save_dir: str = None,
+        criterion: Optional[str] = "",
+        timeout: Optional[float] = 5.0,
+        interval: Optional[float] = 1.0,
+        contains: Optional[bool] = False,  # pylint: disable=unused-argument
+        save_dir: Optional[str] = None,
     ) -> Any:
         """Wait for email matching `criterion` to arrive into INBOX.
 
@@ -794,8 +801,8 @@ class Exchange:
     def save_attachments(
         self,
         message: Union[dict, str],
-        save_dir: str = None,
-        attachments_from_emls: bool = False,
+        save_dir: Optional[str] = None,
+        attachments_from_emls: Optional[bool] = False,
     ) -> list:
         """Save attachments in message into given directory
 
@@ -862,7 +869,7 @@ class Exchange:
         """Save email as .eml file
 
         :param message: dictionary containing message details
-        :param filename:
+        :param filename: name of the file to save message into
         """
         absolute_filepath = Path(filename).resolve()
         if absolute_filepath.suffix != ".eml":

--- a/packages/main/src/RPA/Email/Exchange.py
+++ b/packages/main/src/RPA/Email/Exchange.py
@@ -1,10 +1,11 @@
 import datetime
 import logging
+from multiprocessing import AuthenticationError
 import os
 from pathlib import Path
 import re
 import time
-from typing import Any, Union
+from typing import Any, List, Optional, Union
 import email
 from email import policy  # pylint: disable=no-name-in-module
 import pytz
@@ -48,6 +49,10 @@ EMAIL_CRITERIA_KEYS = {
     "category_contains": "categories__contains",
     "importance": "importance",
 }
+
+
+class NoRecipientsError(ValueError):
+    """Raised when email to be sent does not have any recipients, cc or bcc addresses."""
 
 
 class Exchange:
@@ -195,10 +200,10 @@ class Exchange:
         self,
         username: str,
         password: str,
-        autodiscover: bool = True,
-        access_type: str = "DELEGATE",
-        server: str = None,
-        primary_smtp_address: str = None,
+        autodiscover: Optional[bool] = True,
+        access_type: Optional[str] = "DELEGATE",
+        server: Optional[str] = None,
+        primary_smtp_address: Optional[str] = None,
     ) -> None:
         """Connect to Exchange account
 
@@ -229,11 +234,11 @@ class Exchange:
 
     def list_messages(
         self,
-        folder_name: str = None,
-        criterion: str = None,
-        contains: bool = False,  # pylint: disable=unused-argument
-        count: int = 100,
-        save_dir: str = None,
+        folder_name: Optional[str] = None,
+        criterion: Optional[str] = None,
+        contains: Optional[bool] = False,  # pylint: disable=unused-argument
+        count: Optional[int] = 100,
+        save_dir: Optional[str] = None,
     ) -> list:
         """List messages in the account inbox. Order by descending
         received time.
@@ -263,11 +268,11 @@ class Exchange:
 
     def list_unread_messages(
         self,
-        folder_name: str = None,
-        criterion: str = None,
-        contains: bool = False,
-        count: int = 100,
-        save_dir: str = None,
+        folder_name: Optional[str] = None,
+        criterion: Optional[str] = None,
+        contains: Optional[bool] = False,
+        count: Optional[int] = 100,
+        save_dir: Optional[str] = None,
     ) -> list:
         """List unread messages in the account inbox. Order by descending
         received time.
@@ -292,37 +297,43 @@ class Exchange:
 
     def send_message(
         self,
-        recipients: str,
-        subject: str = "",
-        body: str = "",
-        attachments: str = None,
-        html: bool = False,
-        images: str = None,
-        cc: str = None,
-        bcc: str = None,
-        save: bool = False,
-    ):
+        recipients: Optional[Union[List[str], str]] = None,
+        subject: Optional[str] = "",
+        body: Optional[str] = "",
+        attachments: Optional[Union[List[str], str]] = None,
+        html: Optional[bool] = False,
+        images: Optional[Union[List[str], str]] = None,
+        cc: Optional[Union[List[str], str]] = None,
+        bcc: Optional[Union[List[str], str]] = None,
+        save: Optional[bool] = False,
+    ) -> None:
         """Keyword for sending message through connected Exchange account.
 
-        :param recipients: list of email addresses, defaults to []
+        :param recipients: list of email addresses
         :param subject: message subject, defaults to ""
         :param body: message body, defaults to ""
-        :param attachments: list of filepaths to attach, defaults to []
+        :param attachments: list of filepaths to attach, defaults to `None`
         :param html: if message content is in HTML, default `False`
-        :param images: list of filepaths for inline use, defaults to []
-        :param cc: list of email addresses, defaults to []
-        :param bcc: list of email addresses, defaults to []
+        :param images: list of filepaths for inline use, defaults to `None`
+        :param cc: list of email addresses
+        :param bcc: list of email addresses
         :param save: is sent message saved to Sent messages folder or not,
             defaults to False
 
         Email addresses can be prefixed with ``ex:`` to indicate an Exchange
         account address.
 
-        Recipients is a `required` parameter.
+        At least one target needs to exist for `recipients`, `cc` or `bcc`.
         """
+        if not self.account:
+            raise AuthenticationError("Not authorized to any Exchange account")
         recipients, cc, bcc, attachments, images = self._handle_message_parameters(
             recipients, cc, bcc, attachments, images
         )
+        if not recipients and not cc and not bcc:
+            raise NoRecipientsError(
+                "Atleast one address is required for 'recipients', 'cc' or 'bcc' parameter"
+            )
         self.logger.info("Sending message to %s", ",".join(recipients))
 
         m = Message(
@@ -342,28 +353,27 @@ class Exchange:
         else:
             m.body = body
 
+        # TODO. The exchangelib does not seem to provide any straightforward way of
+        # verifying if message was sent or not
         if save:
             m.folder = self.account.sent
             m.send_and_save()
         else:
             m.send()
-        return True
+        return None
 
     def _handle_message_parameters(self, recipients, cc, bcc, attachments, images):
-        if cc is None:
-            cc = []
-        if bcc is None:
-            bcc = []
-        if attachments is None:
-            attachments = []
-        if images is None:
-            images = []
+        recipients = recipients or []
+        cc = cc or []
+        bcc = bcc or []
+        attachments = attachments or []
+        images = images or []
         if not isinstance(recipients, list):
             recipients = recipients.split(",")
         if not isinstance(cc, list):
-            cc = [cc]
+            cc = cc.split(",")
         if not isinstance(bcc, list):
-            bcc = [bcc]
+            bcc = bcc.split(",")
         if not isinstance(attachments, list):
             attachments = str(attachments).split(",")
         if not isinstance(images, list):

--- a/packages/main/src/RPA/Email/Exchange.py
+++ b/packages/main/src/RPA/Email/Exchange.py
@@ -52,7 +52,7 @@ EMAIL_CRITERIA_KEYS = {
 
 
 class NoRecipientsError(ValueError):
-    """Raised when email to be sent does not have any recipients, cc or bcc addresses."""
+    """Raised when email to be sent does not have any recipients, cc or bcc addresses."""  # noqa: E501
 
 
 class Exchange:
@@ -332,7 +332,7 @@ class Exchange:
         )
         if not recipients and not cc and not bcc:
             raise NoRecipientsError(
-                "Atleast one address is required for 'recipients', 'cc' or 'bcc' parameter"
+                "Atleast one address is required for 'recipients', 'cc' or 'bcc' parameter"  # noqa: E501
             )
         self.logger.info("Sending message to %s", ",".join(recipients))
 
@@ -360,7 +360,6 @@ class Exchange:
             m.send_and_save()
         else:
             m.send()
-        return None
 
     def _handle_message_parameters(self, recipients, cc, bcc, attachments, images):
         recipients = recipients or []

--- a/packages/main/tests/python/test_exchange.py
+++ b/packages/main/tests/python/test_exchange.py
@@ -2,7 +2,7 @@ import datetime
 import mock
 import pytest
 from RPA.Email.Exchange import Exchange, UTC
-
+from RPA.Robocorp.Vault import Vault
 from . import RESOURCES_DIR
 
 
@@ -196,3 +196,20 @@ def test_get_filter_by_key_value_multiple_conditions(library):
     for criteria, expected in criterias.items():
         result = library._get_filter_key_value(criteria)
         assert result == expected
+
+
+@pytest.mark.skip(reason="requires vault and valid email account")
+def test_send_message_with_only_bcc_addresses(library):
+    secrets = Vault().get_secret("Exchange")
+    library.authorize(
+        username=secrets["account"],
+        password=secrets["password"],
+        autodiscover=False,
+        server="outlook.office365.com",
+    )
+    bcc_list = ["robocorp.tester@gmail.com", "robocorp.tester.2@gmail.com"]
+    library.send_message(
+        bcc=bcc_list,
+        subject="test_send_message_with_only_bcc_addresses",
+        body="test_send_message_with_only_bcc_addresses",
+    )

--- a/packages/main/tests/python/test_exchange.py
+++ b/packages/main/tests/python/test_exchange.py
@@ -35,6 +35,13 @@ def test_send_message_with_multiple_recipients(mocked, library):
 
 
 @mock.patch(SENDMAIL_MOCK)
+def test_send_message_with_multiple_recipients_as_list(mocked, library):
+    multi_recipients_as_list = ["person2@domain.com, person3@domain.com"]
+    status = library.send_message(recipients=multi_recipients_as_list)
+    assert status
+
+
+@mock.patch(SENDMAIL_MOCK)
 def test_send_with_subject(mocked, library):
     status = library.send_message(recipients=recipient, subject="My test email subject")
     assert status

--- a/packages/main/tests/robot/test_exchange.robot
+++ b/packages/main/tests/robot/test_exchange.robot
@@ -1,23 +1,95 @@
 *** Settings ***
-Library       RPA.Email.Exchange
-Library       RPA.Robocorp.Vault
-Library       RPA.Tables
-Force tags    skip
+Library           RPA.Email.Exchange
+Library           RPA.Robocorp.Vault
+Library           RPA.Tables
+Library           DateTime
+Force Tags        skip
+Task Setup        Init Variables
 
 *** Variables ***
-@{recipients}       robocorp.tester@gmail.com
+${RESOURCES}      ${CURDIR}${/}..${/}resources
 
 *** Tasks ***
-Sending Email
-    [Documentation]     Sending email with Exchange
-    [Setup]             Init Exchange
-    Send Message
-    ...                 recipients=${recipients}
-    ...                 subject=Order confirmation
-    ...                 body=Thank you for the order!
+Sending Email Without Authorize
+    Run Keyword And Expect Error    AuthenticationError: Not authorized to any Exchange account
+    ...    Send Message
+    ...    recipients=robocorp.tester@gmail.com
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
 
+Sending Email For Single Recipient
+    Init Exchange
+    Send Message
+    ...    recipients=robocorp.tester@gmail.com
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+
+Sending Email For Multiple Recipients as List
+    Init Exchange
+    @{recipients}=    Create List    robocorp.tester@gmail.com    robocorp.tester.2@gmail.com
+    Send Message
+    ...    recipients=${recipients}
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+
+Sending Email For Multiple CC as List
+    Init Exchange
+    @{recipients}=    Create List    robocorp.tester@gmail.com    robocorp.tester.2@gmail.com
+    Send Message
+    ...    cc=${recipients}
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+
+Sending Email For Multiple BCC as List
+    Init Exchange
+    @{recipients}=    Create List    robocorp.tester@gmail.com    robocorp.tester.2@gmail.com
+    Send Message
+    ...    bcc=${recipients}
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+
+Sending Email For Multiple Recipients as String
+    Init Exchange
+    Send Message
+    ...    recipients=robocorp.tester@gmail.com,robocorp.tester.2@gmail.com
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+
+Sending Email With Multiple Attachments as List
+    Init Exchange
+    @{attachments}=    Create List
+    ...    ${RESOURCES}${/}approved.png
+    ...    ${RESOURCES}${/}faces.jpeg
+    Send Message
+    ...    recipients=robocorp.tester@gmail.com
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+    ...    attachments=${attachments}
+
+Sending Email With Multiple Attachments as String
+    Init Exchange
+    Send Message
+    ...    recipients=robocorp.tester@gmail.com
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
+    ...    attachments=${RESOURCES}${/}approved.png,${RESOURCES}${/}faces.jpeg
+
+Sending Email Without Addresses
+    Init Exchange
+    Run Keyword And Expect Error    NoRecipientsError: Atleast one address is required for 'recipients', 'cc' or 'bcc' parameter
+    ...    Send Message
+    ...    subject=${EMAIL_SUBJECT}
+    ...    body=${TEST_NAME}
 
 *** Keywords ***
 Init Exchange
-    ${email}=                   Get secret     exchange
-    Connect With Credentials    AdeleV@beissi.onmicrosoft.com   ${email}[password]
+    ${email}=    Get secret    Exchange
+    Authorize
+    ...    username=${email}[account]
+    ...    password=${email}[password]
+    ...    autodiscover=False
+    ...    server=outlook.office365.com
+
+Init Variables
+    ${timestamp}=    Get Current Date
+    Set Global Variable    ${EMAIL_SUBJECT}    From rpaframework tests - ${timestamp}


### PR DESCRIPTION
- Type hints fixed
- Added support for `Send Message` keyword so that message can be sent with any combination of `recipients`, `cc `or `bcc` addresses. This means for example that message can be sent with only `bcc `addresses or with only `cc `addresses.

Robot Framework example.
```robotframework
    @{recipients}=    Create List    address1@domain.com    address2@domain.com
    Send Message
    ...    bcc=${recipients}
    ...    subject=${EMAIL_SUBJECT}
    ...    body=${TEST_NAME}
```

Python example.
```python
    bcc_list = ["address1@domain.com", "address2@domain.com"]
    library.send_message(
        bcc=bcc_list ,
        subject="test_send_message_with_only_bcc_addresses",
        body="test_send_message_with_only_bcc_addresses",
    )
```

Robot Framework tests have been updated
https://github.com/robocorp/rpaframework/blob/477-rpaemailexchange-fix-parameter-types-for-send-message-keyword/packages/main/tests/robot/test_exchange.robot