### PR TITLE
Fix the `Blocks` and `RPA.Tables` issues in the `RPA.Cloud.AWS` library

### DIFF
--- a/packages/aws/poetry.lock
+++ b/packages/aws/poetry.lock
@@ -113,14 +113,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.22.4"
+version = "1.22.5"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.25.4,<1.26.0"
+botocore = ">=1.25.5,<1.26.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -129,7 +129,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.25.4"
+version = "1.25.5"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -1042,12 +1042,11 @@ black = [
     {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 boto3 = [
-    {file = "boto3-1.22.4-py3-none-any.whl", hash = "sha256:13fe18ecefe342d2fe50ae7b4305d7423ec6e96bfaef19bc2f14212877a67727"},
-    {file = "boto3-1.22.4.tar.gz", hash = "sha256:71019d49562112bcf8c2e5c183f3cca263edf02785e6a2c5f98ee104927cbb44"},
+    {file = "boto3-1.22.5-py3-none-any.whl", hash = "sha256:e6b4a4970cb9210d455f348577d9e0485f86c44baf278b8220e8ab5587d03470"},
+    {file = "boto3-1.22.5.tar.gz", hash = "sha256:dbbeee6d535a311d4d646a9dd683b216bf17d59345367432a22a21b50eb43a8e"},
 ]
 botocore = [
-    {file = "botocore-1.25.4-py3-none-any.whl", hash = "sha256:0a7b56eda54af6cb210894113f59fb0e2aaf07893d839de292d9c7b07f626dde"},
-    {file = "botocore-1.25.4.tar.gz", hash = "sha256:71cf60ccb024d3c925424d28eba9ca953fc13f36a345dca177b080971ed1141a"},
+    {file = "botocore-1.25.5-py3-none-any.whl", hash = "sha256:bcbacc0ec0a1f44cbf7e6d8112af8096eed41bec75e90af06f8bf61f20d820aa"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},

--- a/packages/aws/pyproject.toml
+++ b/packages/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-aws"
-version = "2.0.0"
+version = "2.0.1"
 description = "AWS library for RPA Framework"
 authors = [
 	"RPA Framework <rpafw@robocorp.com>",

--- a/packages/aws/src/RPA/Cloud/AWS/__init__.py
+++ b/packages/aws/src/RPA/Cloud/AWS/__init__.py
@@ -648,7 +648,8 @@ class ServiceTextract(AWSBase):
         total_result = response
         if len(total_blocks) > 0:
             total_result["Blocks"] = total_blocks
-        self.logger.info("Returning %s blocks" % len(total_result["Blocks"]))
+        if "Blocks" in total_result.keys():
+            self.logger.info("Returning %s blocks" % len(total_result["Blocks"]))
         return total_result
 
     def get_pages_and_text(self, textract_response: dict) -> dict:

--- a/packages/aws/src/RPA/Cloud/AWS/__init__.py
+++ b/packages/aws/src/RPA/Cloud/AWS/__init__.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+
 from RPA.core.logger import RobotLogListener
 from RPA.core.helpers import required_param, required_env
 
@@ -39,6 +40,19 @@ def import_vault():
     except ModuleNotFoundError:
         pass
     return None
+
+
+def import_tables():
+    """Try to import Tables library"""
+    try:
+        module = importlib.import_module("RPA.Tables")
+        return getattr(module, "Tables")
+    except ModuleNotFoundError:
+        logging.getLogger().info(
+            "Tables in the AWS response will be in a `dictionary` type, "
+            "because `RPA.Tables` library is not available in the scope."
+        )
+        return None
 
 
 def aws_dependency_required(f):
@@ -490,13 +504,16 @@ class ServiceTextract(AWSBase):
                 else:
                     rows[row] = {col: val}
 
+            tables = import_tables()
             data = [
                 [rows[col][idx] for idx in sorted(rows[col])] for col in sorted(rows)
             ]
-            self.tables[idx] = data
+            self.tables[idx] = tables().create_table(data) if tables else data
 
     def get_tables(self):
         """Get parsed tables from the response
+
+        Returns `RPA.Tables.Table` if possible otherwise returns an dictionary.
 
         :return: tables
         """
@@ -770,7 +787,8 @@ class ServiceTextract(AWSBase):
         total_result = response
         if len(total_blocks) > 0:
             total_result["Blocks"] = total_blocks
-        self.logger.info("Returning %s blocks" % len(total_result["Blocks"]))
+        if "Blocks" in total_result.keys():
+            self.logger.info("Returning %s blocks" % len(total_result["Blocks"]))
         return total_result
 
     def convert_textract_response_to_model(self, response):


### PR DESCRIPTION
- The error related to `Blocks` key was caused by incorrect access to dictionary keys while logging in the keyword `Get Document Analysis`
- `RPA.Tables` support was removed when `rpaframework-aws` package was created. Support has been now added back if `RPA.Tables` library can be imported then `Table` object is returned by keyword `Get Tables`, if library can not be imported then `dictionary` containing AWS document tables is returned.