### PR TITLE
Excel: Files: Fix issues with removing worksheets

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -21,6 +21,10 @@ Release notes
   ``email[body]`` payload variable the e-mail body on e-mail Process triggering with
   "Parse email" configuration option enabled in Control Room.
 
+- Library **RPA.Excel.Files***:
+
+  - Fix IndexError when removing .xls worksheets
+  - Fix removing currently active worksheet
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Excel/Files.py
+++ b/packages/main/src/RPA/Excel/Files.py
@@ -787,6 +787,14 @@ class XlsxWorkbook:
 
     def remove_worksheet(self, name=None):
         name = self._get_sheetname(name)
+        others = [sheet for sheet in self.sheetnames if sheet != name]
+
+        if not others:
+            raise ValueError("Workbook must have at least one other worksheet")
+
+        if name == self.active:
+            self.active = others[0]
+
         sheet = self._book[name]
         self._book.remove(sheet)
 
@@ -1073,9 +1081,13 @@ class XlsWorkbook:
 
     def remove_worksheet(self, name=None):
         name = self._get_sheetname(name)
+        others = [sheet for sheet in self.sheetnames if sheet != name]
+
+        if not others:
+            raise ValueError("Workbook must have at least one other worksheet")
 
         if name == self.active:
-            self.active = self.sheetnames[0]
+            self.active = others[0]
 
         with self._book_write() as book:
             # This is pretty ugly, but there seems to be no other way to

--- a/packages/main/src/RPA/Excel/Files.py
+++ b/packages/main/src/RPA/Excel/Files.py
@@ -1096,6 +1096,11 @@ class XlsWorkbook:
             book._Workbook__worksheets = [
                 sheet for sheet in book._Workbook__worksheets if sheet.name != name
             ]
+            book._Workbook__active_sheet = next(
+                idx
+                for idx, sheet in enumerate(book._Workbook__worksheets)
+                if sheet.name == self.active
+            )
 
     def rename_worksheet(self, title, name=None):
         title = str(title)

--- a/packages/main/tests/python/test_excel.py
+++ b/packages/main/tests/python/test_excel.py
@@ -278,8 +278,14 @@ def test_append_to_worksheet_empty_with_headers(fmt):
 
 
 def test_remove_worksheet(library):
+    library.set_active_worksheet("Second")
+
     library.remove_worksheet("Second")
     assert library.list_worksheets() == ["First"]
+    assert library.get_active_worksheet() == "First"
+
+    with pytest.raises(ValueError):
+        library.remove_worksheet("First")
 
 
 def test_rename_worksheet(library):


### PR DESCRIPTION
- Fix IndexError when removing (certain) worksheets from XLS workbooks
- Reset active worksheet if it is deleted
- Ensure the last worksheet can not be deleted

Original issue reported internally by @TimothyLopas