### PR TITLE
Add GMail support for OAuth2 flow

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -17,11 +17,18 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-- Library **RPA.Excel.Files** (:pr:`490`): Keyword examples updated to be more complete
-  and Python examples have been added to all keywords.
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+14.1.1 - 12 May 2022
+--------------------
+
+- Library **RPA.Email.ImapSmtp** (:issue:`500`): Keywords ``Authorize[ Imap/Smtp]``
+  support `is_oauth` parameter which instructs the client to authenticate through the
+  basic (`False`) or XOAUTH2 (`True`) protocol.
+- Library **RPA.Excel.Files** (:pr:`490`): Keyword examples updated to be more complete
+  and Python examples have been added to all keywords.
 
 14.1.0 - 05 May 2022
 --------------------

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -143,14 +143,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.22.8"
+version = "1.22.12"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.25.8,<1.26.0"
+botocore = ">=1.25.12,<1.26.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -159,7 +159,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.25.8"
+version = "1.25.12"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -327,7 +327,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "exchangelib"
-version = "4.7.2"
+version = "4.7.3"
 description = "Client for Microsoft Exchange Web Services (EWS)"
 category = "main"
 optional = false
@@ -537,7 +537,7 @@ python-versions = "*"
 
 [[package]]
 name = "invoke"
-version = "1.7.0"
+version = "1.7.1"
 description = "Pythonic task execution"
 category = "dev"
 optional = false
@@ -616,7 +616,7 @@ six = "*"
 
 [[package]]
 name = "jsonschema"
-version = "4.5.0"
+version = "4.5.1"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -1069,7 +1069,7 @@ pyobjc-framework-Cocoa = ">=7.3"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.8"
+version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
@@ -2169,12 +2169,12 @@ black = [
     {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 boto3 = [
-    {file = "boto3-1.22.8-py3-none-any.whl", hash = "sha256:a6925fe88cc9cd6aab35ea950cdb1678a88210ece5271bb64c1593a46ed6de6c"},
-    {file = "boto3-1.22.8.tar.gz", hash = "sha256:222cfb68bd4f46f4beae7770f1f6b066786254462f289027ca123fe77eb50ff9"},
+    {file = "boto3-1.22.12-py3-none-any.whl", hash = "sha256:9830d7f8748c164a3f0929d8a0c5bb313cc62d7cf69ce55617108bed451a8520"},
+    {file = "boto3-1.22.12.tar.gz", hash = "sha256:4b3a49abf7a5f7cdd82714a3ae356a9a8ce12a668e014c5fc68454aa1e2fc0cb"},
 ]
 botocore = [
-    {file = "botocore-1.25.8-py3-none-any.whl", hash = "sha256:5b342da3487e5669801f5589cc15e379fc9f7803a426584d08a6329575644da3"},
-    {file = "botocore-1.25.8.tar.gz", hash = "sha256:f0a7e9fb6000a6cfc7ca63971d8d1ab4ed3c38514ded439bcf1fc8bca162dc1b"},
+    {file = "botocore-1.25.12-py3-none-any.whl", hash = "sha256:53e19890124be45e47ec4f7ffdaf587343d375dbd7c7a501e55aeff80680fec0"},
+    {file = "botocore-1.25.12.tar.gz", hash = "sha256:e2fc586fdc0b54c08fc509e906e87fb358b9f5607b12f526f995ee74a4a4bcd3"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -2341,8 +2341,8 @@ et-xmlfile = [
     {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
 ]
 exchangelib = [
-    {file = "exchangelib-4.7.2-py2.py3-none-any.whl", hash = "sha256:66e3345a0a452c6f2d10c6b33f0da0598f50f2b0d848082e8d4cf47e89afdf0e"},
-    {file = "exchangelib-4.7.2.tar.gz", hash = "sha256:6d19f4d7235003166d89e4c95414af9ffbaa2e9a1d1402e90e8cda5281191fd2"},
+    {file = "exchangelib-4.7.3-py2.py3-none-any.whl", hash = "sha256:8edcd90257b7f83518af77909ba11bcd6fb9b3867348fbaeaf5b9a6993bb9280"},
+    {file = "exchangelib-4.7.3.tar.gz", hash = "sha256:ffc65a0819064a39998eac6f36c5be1b2643f589d2f4d695e6b6db00d3735069"},
 ]
 fire = [
     {file = "fire-0.4.0.tar.gz", hash = "sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62"},
@@ -2488,8 +2488,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 invoke = [
-    {file = "invoke-1.7.0-py3-none-any.whl", hash = "sha256:a5159fc63dba6ca2a87a1e33d282b99cea69711b03c64a35bb4e1c53c6c4afa0"},
-    {file = "invoke-1.7.0.tar.gz", hash = "sha256:e332e49de40463f2016315f51df42313855772be86435686156bc18f45b5cc6c"},
+    {file = "invoke-1.7.1-py3-none-any.whl", hash = "sha256:2dc975b4f92be0c0a174ad2d063010c8a1fdb5e9389d69871001118b4fcac4fb"},
+    {file = "invoke-1.7.1.tar.gz", hash = "sha256:7b6deaf585eee0a848205d0b8c0014b9bf6f287a8eb798818a642dff1df14b19"},
 ]
 isodate = [
     {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
@@ -2517,8 +2517,8 @@ jsonpath-ng = [
     {file = "jsonpath_ng-1.5.3-py3-none-any.whl", hash = "sha256:292a93569d74029ba75ac2dc3d3630fc0e17b2df26119a165fa1d498ca47bf65"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.5.0-py3-none-any.whl", hash = "sha256:71440faf604ccc4958f0a54fad16fa24e4977256f9666a21e8ad59a5447bd0b0"},
-    {file = "jsonschema-4.5.0.tar.gz", hash = "sha256:19462141d4efb2d8046cd4a7076126c5bdb1dd04f6fb9129b46b4b8f7b0de355"},
+    {file = "jsonschema-4.5.1-py3-none-any.whl", hash = "sha256:71b5e39324422543546572954ce71c67728922c104902cb7ce252e522235b33f"},
+    {file = "jsonschema-4.5.1.tar.gz", hash = "sha256:7c6d882619340c3347a1bf7315e147e6d3dae439033ae6383d6acb908c101dfc"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
@@ -2996,8 +2996,8 @@ pyobjc-framework-quartz = [
     {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7aba3cd966a0768dd58a35680742820f0c5ac596a9cd11014e2057818e65b0af"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
-    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pypdf2 = [
     {file = "PyPDF2-1.27.9-py3-none-any.whl", hash = "sha256:5e29ffaf2efcfb77c25206e3b8df517a18af84e64ebe1b3a93abac8d01176374"},

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "14.1.0"
+version = "14.1.1"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -294,7 +294,9 @@ class ImapSmtp:
                 self.smtp_conn = SMTP_SSL(smtp_server, smtp_port, context=context)
             if account and password:
                 if is_oauth:
-                    self.smtp_conn.docmd("AUTH", "XOAUTH2 " + password)
+                    self.smtp_conn.auth(
+                        "XOAUTH2", lambda: base64.b64decode(password.encode()).decode()
+                    )
                 else:
                     self.smtp_conn.login(account, password)
         else:
@@ -340,7 +342,7 @@ class ImapSmtp:
             self.imap_conn = IMAP4_SSL(imap_server, imap_port)
             if is_oauth:
                 self.imap_conn.authenticate(
-                    "XOAUTH2", lambda _: base64.b64decode(password.encode()).decode()
+                    "XOAUTH2", lambda _: base64.b64decode(password.encode())
                 )
             else:
                 self.imap_conn.login(account, password)

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -123,6 +123,8 @@ class ImapSmtp:
 
     - Authentication error with Gmail - "Application-specific password required"
         see. https://support.google.com/mail/answer/185833?hl=en
+    - More secure apps (XOAUTH2 protocol): Check
+        `example-oauth-email <https://github.com/robocorp/example-oauth-email>`_
 
     **Examples**
 
@@ -266,6 +268,8 @@ class ImapSmtp:
         :param password: SMTP account password, defaults to None
         :param smtp_server: SMTP server address, defaults to None
         :param smtp_port: SMTP server port, defaults to None (587 for SMTP)
+        :param is_oauth: Use XOAUTH2 protocol with a base64 encoded OAuth2 string as
+            `password`
 
         Can be called without giving any parameters if library
         has been initialized with necessary information and/or
@@ -318,6 +322,8 @@ class ImapSmtp:
         :param password: IMAP account password, defaults to None
         :param imap_server: IMAP server address, defaults to None
         :param imap_port: IMAP server port, defaults to None
+        :param is_oauth: Use XOAUTH2 protocol with a base64 encoded OAuth2 string as
+            `password`
 
         Can be called without giving any parameters if library
         has been initialized with necessary information and/or
@@ -374,6 +380,8 @@ class ImapSmtp:
         :param imap_server: IMAP server address, defaults to None
         :param smtp_port: SMTP server port, defaults to None (587 for SMTP)
         :param imap_port: IMAP server port, defaults to None
+        :param is_oauth: Use XOAUTH2 protocol with a base64 encoded OAuth2 string as
+            `password`
 
         Will use separately set credentials or those given in keyword call.
 

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -339,7 +339,9 @@ class ImapSmtp:
         if imap_server and account and password:
             self.imap_conn = IMAP4_SSL(imap_server, imap_port)
             if is_oauth:
-                self.imap_conn.authenticate("XOAUTH2", lambda _: base64.b64decode(password.encode()).decode())
+                self.imap_conn.authenticate(
+                    "XOAUTH2", lambda _: base64.b64decode(password.encode()).decode()
+                )
             else:
                 self.imap_conn.login(account, password)
             self.imap_conn.select("INBOX")
@@ -379,8 +381,12 @@ class ImapSmtp:
 
             Authorize    ${username}   ${password}  smtp_server=smtp.gmail.com  smtp_port=587
         """  # noqa: E501
-        self.authorize_smtp(account, password, smtp_server, smtp_port, is_oauth=is_oauth)
-        self.authorize_imap(account, password, imap_server, imap_port, is_oauth=is_oauth)
+        self.authorize_smtp(
+            account, password, smtp_server, smtp_port, is_oauth=is_oauth
+        )
+        self.authorize_imap(
+            account, password, imap_server, imap_port, is_oauth=is_oauth
+        )
 
     @smtp_connection
     def send_smtp_hello(self) -> None:

--- a/packages/main/tests/resources/secrets.yaml
+++ b/packages/main/tests/resources/secrets.yaml
@@ -15,3 +15,10 @@ windows:
     domain: windows
     login: robot
     password: secret
+gmail:
+    account: cosmin@robocorp.com
+#    password: y*** **** **** ***r  # App Password (is_oauth: false)
+    password: dXNlc*********tSTm1BM0dRQkIBAQ==  # OAuth2 string (is_oauth: true)
+    smtpserver: smtp.gmail.com
+    imapserver: imap.gmail.com
+    is_oauth: true

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "amazon-textract-response-parser"
-version = "0.1.29"
+version = "0.1.30"
 description = "Easily parse JSON returned by Amazon Textract."
 category = "main"
 optional = false
@@ -135,14 +135,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.22.7"
+version = "1.22.12"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.25.7,<1.26.0"
+botocore = ">=1.25.12,<1.26.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -151,7 +151,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.25.7"
+version = "1.25.12"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -316,7 +316,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "exchangelib"
-version = "4.7.2"
+version = "4.7.3"
 description = "Client for Microsoft Exchange Web Services (EWS)"
 category = "main"
 optional = false
@@ -839,7 +839,7 @@ six = "*"
 
 [[package]]
 name = "jsonschema"
-version = "4.4.0"
+version = "4.5.1"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -1255,7 +1255,7 @@ pyobjc-framework-Cocoa = ">=7.3"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.8"
+version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "main"
 optional = false
@@ -1650,7 +1650,7 @@ python-versions = "*"
 
 [[package]]
 name = "rpaframework"
-version = "14.0.0"
+version = "14.1.1"
 description = "A collection of tools and libraries for RPA"
 category = "main"
 optional = false
@@ -2338,8 +2338,8 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 amazon-textract-response-parser = [
-    {file = "amazon-textract-response-parser-0.1.29.tar.gz", hash = "sha256:453236ae3cb204e43915ba7b98870befcf47f8a9967bafa7f67ec5b8452b7dcd"},
-    {file = "amazon_textract_response_parser-0.1.29-py2.py3-none-any.whl", hash = "sha256:f4f117a732abc3c902c0c8256c5da34910a0d3535f08dbd63037ac8b8c2b3a9e"},
+    {file = "amazon-textract-response-parser-0.1.30.tar.gz", hash = "sha256:e70f602ded8bd1f4a274bcb2cb6234078d20bace55afcc67f500a6bbc40f6e19"},
+    {file = "amazon_textract_response_parser-0.1.30-py2.py3-none-any.whl", hash = "sha256:eaf2c9ed0c6b1a719d79cdc3910fe3a94da2b4759de680ca573cc9a53e97cc1e"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -2413,12 +2413,12 @@ black = [
     {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 boto3 = [
-    {file = "boto3-1.22.7-py3-none-any.whl", hash = "sha256:de4fa49ca1cbc93313144e93e6d0997cbb61c8cca91f3418b4e3646dc215f441"},
-    {file = "boto3-1.22.7.tar.gz", hash = "sha256:4dc0df36c3465ff0d586017da68b0152123695f38f30ad98fed7185e59298d2c"},
+    {file = "boto3-1.22.12-py3-none-any.whl", hash = "sha256:9830d7f8748c164a3f0929d8a0c5bb313cc62d7cf69ce55617108bed451a8520"},
+    {file = "boto3-1.22.12.tar.gz", hash = "sha256:4b3a49abf7a5f7cdd82714a3ae356a9a8ce12a668e014c5fc68454aa1e2fc0cb"},
 ]
 botocore = [
-    {file = "botocore-1.25.7-py3-none-any.whl", hash = "sha256:83da857c12fff5cf4c1a64afaa72a28ff5bef929a2834ec4ed5b0b674f88fd0e"},
-    {file = "botocore-1.25.7.tar.gz", hash = "sha256:190361776d96323ff401b976175f76172acf7ebbe3efbb19c4c6f9800a9ad6b6"},
+    {file = "botocore-1.25.12-py3-none-any.whl", hash = "sha256:53e19890124be45e47ec4f7ffdaf587343d375dbd7c7a501e55aeff80680fec0"},
+    {file = "botocore-1.25.12.tar.gz", hash = "sha256:e2fc586fdc0b54c08fc509e906e87fb358b9f5607b12f526f995ee74a4a4bcd3"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -2546,8 +2546,8 @@ et-xmlfile = [
     {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
 ]
 exchangelib = [
-    {file = "exchangelib-4.7.2-py2.py3-none-any.whl", hash = "sha256:66e3345a0a452c6f2d10c6b33f0da0598f50f2b0d848082e8d4cf47e89afdf0e"},
-    {file = "exchangelib-4.7.2.tar.gz", hash = "sha256:6d19f4d7235003166d89e4c95414af9ffbaa2e9a1d1402e90e8cda5281191fd2"},
+    {file = "exchangelib-4.7.3-py2.py3-none-any.whl", hash = "sha256:8edcd90257b7f83518af77909ba11bcd6fb9b3867348fbaeaf5b9a6993bb9280"},
+    {file = "exchangelib-4.7.3.tar.gz", hash = "sha256:ffc65a0819064a39998eac6f36c5be1b2643f589d2f4d695e6b6db00d3735069"},
 ]
 fire = [
     {file = "fire-0.4.0.tar.gz", hash = "sha256:c5e2b8763699d1142393a46d0e3e790c5eb2f0706082df8f647878842c216a62"},
@@ -2823,8 +2823,8 @@ jsonpath-ng = [
     {file = "jsonpath_ng-1.5.3-py3-none-any.whl", hash = "sha256:292a93569d74029ba75ac2dc3d3630fc0e17b2df26119a165fa1d498ca47bf65"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
-    {file = "jsonschema-4.4.0.tar.gz", hash = "sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83"},
+    {file = "jsonschema-4.5.1-py3-none-any.whl", hash = "sha256:71b5e39324422543546572954ce71c67728922c104902cb7ce252e522235b33f"},
+    {file = "jsonschema-4.5.1.tar.gz", hash = "sha256:7c6d882619340c3347a1bf7315e147e6d3dae439033ae6383d6acb908c101dfc"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
@@ -3320,8 +3320,8 @@ pyobjc-framework-quartz = [
     {file = "pyobjc_framework_Quartz-7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7aba3cd966a0768dd58a35680742820f0c5ac596a9cd11014e2057818e65b0af"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
-    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pypdf2 = [
     {file = "PyPDF2-1.27.9-py3-none-any.whl", hash = "sha256:5e29ffaf2efcfb77c25206e3b8df517a18af84e64ebe1b3a93abac8d01176374"},


### PR DESCRIPTION
- OAuth2 tokens and auth strings generated by following the steps described on [OAuth2DotPyRunThrough](https://github.com/google/gmail-oauth2-tools/wiki/OAuth2DotPyRunThrough).
- Tested with this [robot](https://github.com/cmin764/robots/blob/main/gmail-auth/tasks.robot) (note the extra `is_oauth` param):
  ```robotframework
  Authorize    account=${creds}[username]    password=${creds}[password]    is_oauth=${is_oauth}
  ```

### ToDo
- [x] Unit & robot tests
- [x] Docstring update & linting (+ release notes)
- [x] Test with Vault in Control Room given this [example-oauth-email](https://github.com/robocorp/example-oauth-email)