### PR TITLE
Implement `invoke` instead of `make` at meta package level

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,5 @@
 from glob import glob
+import os
 import platform
 import re
 import shutil
@@ -33,6 +34,13 @@ CLEAN_PATTERNS = [
     ".venv",
     ".mypy_cache",
 ]
+DOCS_CLEAN_PATTERNS = [
+    "docs/build",
+    "docs/source/libspec",
+    "docs/source/include/libdoc",
+    "docs/source/include/latest.json",
+    "docs/source/json",
+]
 
 
 def _get_package_paths():
@@ -62,15 +70,28 @@ def pip(ctx, command, **kwargs):
     return _run(ctx, "pip", command, **kwargs)
 
 
-@task
-def clean(ctx):
+@task()
+def clean(ctx, venv=True, docs=False):
     """Cleans the virtual development environment by
     completely removing build artifacts and the .venv.
+    You can set ``--no-venv`` to avoid this default.
+
+    If ``--docs`` is supplied, the build artifacts for
+    local documentation will also be cleaned.
     """
-    for pattern in CLEAN_PATTERNS:
+    union_clean_patterns = []
+    if venv:
+        union_clean_patterns.extend(CLEAN_PATTERNS)
+    if docs:
+        union_clean_patterns.extend(DOCS_CLEAN_PATTERNS)
+    for pattern in union_clean_patterns:
         for path in glob(pattern, recursive=True):
             print(f"Removing: {path}")
             shutil.rmtree(path, ignore_errors=True)
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -3,10 +3,16 @@ import os
 import platform
 import re
 import shutil
-import toml
 import subprocess
 from pathlib import Path
-from invoke import task, call
+from invoke import task, call, ParseError
+
+try:
+    import toml
+except ModuleNotFoundError:
+    DEPENDENCIES_AVAILABLE = False
+else:
+    DEPENDENCIES_AVAILABLE = True
 
 
 def _git_root():
@@ -70,14 +76,22 @@ def pip(ctx, command, **kwargs):
     return _run(ctx, "pip", command, **kwargs)
 
 
+def package_invoke(ctx, directory, command, **kwargs):
+    with ctx.cd(directory):
+        return _run(ctx, "invoke", command, **kwargs)
+
+
 @task()
-def clean(ctx, venv=True, docs=False):
+def clean(ctx, venv=True, docs=False, all=False):
     """Cleans the virtual development environment by
     completely removing build artifacts and the .venv.
     You can set ``--no-venv`` to avoid this default.
 
     If ``--docs`` is supplied, the build artifacts for
     local documentation will also be cleaned.
+
+    You can set flag ``all`` to clean all packages as
+    well.
     """
     union_clean_patterns = []
     if venv:
@@ -92,34 +106,78 @@ def clean(ctx, venv=True, docs=False):
                 os.remove(path)
             except OSError:
                 pass
+    if all:
+        our_packages = _get_package_paths()
+        for package_path in our_packages.values():
+            package_invoke(ctx, package_path, "clean")
 
 
 @task
+def setup_poetry(ctx, username=None, password=None, token=None):
+    """Configure local poetry installation for development.
+    If you provide ``username`` and ``password``, you can
+    also configure your pypi access. Our version of poetry
+    uses ``keyring`` so the password is not stored in the
+    clear.
+
+    Alternatively, you can set ``token`` to use a pypi token, be sure
+    to include the ``pypi-`` prefix in the token.
+    """
+    poetry(ctx, "config -n --local virtualenvs.in-project true")
+    poetry(ctx, "config -n --local virtualenvs.create true")
+    poetry(ctx, "config -n --local virtualenvs.path null")
+    poetry(ctx, "config -n --local experimental.new-installer true")
+    poetry(ctx, "config -n --local installer.parallel true")
+    poetry(
+        ctx,
+        "config -n --local repositories.devpi.url https://devpi.robocorp.cloud/ci/test",
+    )
+    if username and password and token:
+        raise ParseError(
+            "You cannot specify username-password combination and token simultaneously"
+        )
+    if username ^ password:
+        raise ParseError("You must specify both username and password")
+    if username and password:
+        poetry(ctx, f"config -n http-basic.pypi {username} {password}")
+    if token:
+        poetry(ctx, f"config -n pypi-token.pypi {token}")
+
+
+@task(pre=[setup_poetry])
 def install(ctx, reset=False):
     """Install development environment. If ``reset`` is set,
     poetry will remove untracked packages, reverting the
     .venv to the lock file.
+
+    If ``reset`` is attempted before an initial install, it
+    is ignored.
     """
-    if reset:
-        our_packages = _get_package_paths()
-        with ctx.prefix(ACTIVATE):
-            pip_freeze = pip(ctx, "freeze", echo=False, hide="out")
-            # Identifies locally installed packages in development mode.
-            #  (not from PyPI)
-            package_exprs = [
-                rf"{name}(?=={{2}})" for name in our_packages if name != "rpaframework"
-            ]
-            pattern = "|".join(package_exprs)
-            local_packages = re.findall(
-                pattern,
-                pip_freeze.stdout,
-                re.MULTILINE | re.IGNORECASE,
-            )
-            for local_package in local_packages:
-                pip(ctx, f"uninstall {local_package} -y")
-        poetry(ctx, "install --remove-untracked")
-    else:
+    if not DEPENDENCIES_AVAILABLE:
         poetry(ctx, "install")
+    else:
+        if reset:
+            our_packages = _get_package_paths()
+            with ctx.prefix(ACTIVATE):
+                pip_freeze = pip(ctx, "freeze", echo=False, hide="out")
+                # Identifies locally installed packages in development mode.
+                #  (not from PyPI)
+                package_exprs = [
+                    rf"{name}(?=={{2}})"
+                    for name in our_packages
+                    if name != "rpaframework"
+                ]
+                pattern = "|".join(package_exprs)
+                local_packages = re.findall(
+                    pattern,
+                    pip_freeze.stdout,
+                    re.MULTILINE | re.IGNORECASE,
+                )
+                for local_package in local_packages:
+                    pip(ctx, f"uninstall {local_package} -y")
+            poetry(ctx, "install --remove-untracked")
+        else:
+            poetry(ctx, "install")
 
 
 @task(pre=[call(install, reset=True)], iterable=["package"])


### PR DESCRIPTION
Implements a collection of `invoke` tasks which completely replaces the meta package `makefile`. You can use `invoke --list` from the repository root directory to see available invocations. Each invocation also includes help output, accessible via `invoke <task> --help`

If you do not have invoke installed globally, you can use `poetry install` then `poetry run invoke ...`. 

The tasks utilize asynchronous runs were possible to improve performance, as you can see from my pwsh:

```powershell
PS C:\Users\boome\Documents\GitHub\robo-rpaframework> Measure-Command {inv build-docs}

Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 26
Milliseconds      : 36
Ticks             : 860365302
TotalDays         : 0.000995793173611111
TotalHours        : 0.0238990361666667
TotalMinutes      : 1.43394217
TotalSeconds      : 86.0365302
TotalMilliseconds : 86036.5302

PS C:\Users\boome\Documents\GitHub\robo-rpaframework> Measure-Command {make docs}     

Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 41
Milliseconds      : 531
Ticks             : 1015318987
TotalDays         : 0.00117513771643519
TotalHours        : 0.0282033051944444
TotalMinutes      : 1.69219831166667
TotalSeconds      : 101.5318987
TotalMilliseconds : 101531.8987
```