### PR TITLE
`RPA.Desktop` docs examples fix on `Region` element

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,6 +5,8 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.Desktop**: Fix docs examples returning ``Region`` elements.
+
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Desktop/keywords/finder.py
+++ b/packages/main/src/RPA/Desktop/keywords/finder.py
@@ -270,7 +270,7 @@ class FinderKeywords(LibraryContext):
 
             ${matches}=    Find elements    image:icon.png
             FOR    ${match}  IN  @{matches}
-                Log    Found icon at ${match.x}, ${match.y}
+                Log    Found icon at ${match.right}, ${match.top}
             END
         """
         self.logger.info("Resolving locator: %s", locator)
@@ -293,7 +293,7 @@ class FinderKeywords(LibraryContext):
         .. code-block:: robotframework
 
             ${match}=    Find element    image:logo.png
-            Log    Found logo at ${match.x}, ${match.y}
+            Log    Found logo at ${match.right}, ${match.top}
         """
         matches = self.find_elements(locator)
 


### PR DESCRIPTION
This raised my interest when I was dealing with this robot [example](https://github.com/cmin764/robots/blob/main/desktop-auto/tasks.robot#L262-L266). (given customer Slack [thread](https://robocorp-developers.slack.com/archives/C03LKL6PKC5/p1655979058624539))