### PR TITLE
`RPA.Cloud.AWS` - Add keyword "Generate Presigned URL"

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -8,6 +8,11 @@ Release notes
 30 Sep 2022
 -----------
 
+- Library `RPA.Cloud.AWS` (:pr:`648`): 
+
+  - Add new keyword ``Generate Presigned URL`` for S3
+  - Released in ``rpaframework-aws`` **5.1.0**
+
 - Library `RPA.Windows` (:pr:`647`): 
 
   - Add new keywords ``Drag and Drop`` and ``Set Focus``

--- a/packages/aws/pyproject.toml
+++ b/packages/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-aws"
-version = "5.1.0a6"
+version = "5.1.0"
 description = "AWS library for RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/aws/src/RPA/Cloud/AWS/__init__.py
+++ b/packages/aws/src/RPA/Cloud/AWS/__init__.py
@@ -457,6 +457,39 @@ class ServiceS3(AWSBase):
 
         return download_count
 
+    @aws_dependency_required
+    def generate_presigned_url(
+        self,
+        bucket_name: str,
+        object_name: str,
+        expires_in: Optional[int] = None,
+        **extra_params,
+    ) -> tuple:
+        """Generate presigned URL for the file.
+
+        :param bucket_name: name for the bucket
+        :param object_name: name of the file in the bucket
+        :param expires_in: optional expiration time for the url (in seconds).
+         The default expiration time is 3600 seconds (one hour).
+        :param **extra_params: allows setting any extra `Params`
+        :return: URL for accessing the file
+        """
+        client = self._get_client_for_service("s3")
+        response = None
+        try:
+            request_params = {
+                "Params": {"Bucket": bucket_name, "Key": object_name, **extra_params}
+            }
+            if expires_in:
+                request_params["ExpiresIn"] = int(expires_in)
+            response = client.generate_presigned_url(
+                "get_object",
+                **request_params,
+            )
+        except ClientError as e:
+            self.logger.error("Client request error: %s", str(e))
+        return response
+
 
 class ServiceTextract(AWSBase):
     """Class for AWS Textract service"""


### PR DESCRIPTION
Allows sharing S3 files via presigned URLs. Default expiration time is 3600 seconds (1 hour), but parameter ``expires_in`` can be used to any custom time (need to be in seconds).

```robotframework
${expiration_time}=    Set Variable    ${20}
${secrets}=    Get Secret    aws
Init S3 Client    ${secrets}[key]    ${secrets}[secret]    ${secrets}[region]
${presigned_url}=    Generate Presigned Url
...    testing-s3-changes
...    pw.png
...    expires_in=${expiration_time}
${share_start}=    Evaluate    time.time()
Log To Console    \nURL: ${presigned_url}
Log To Console    EXPIRES IN: ${expiration_time} seconds\n
FOR    ${i}    IN RANGE    ${expiration_time+5}
    Sleep    1s
    ${timediff}=    Evaluate    round(time.time()-$share_start,1)
    TRY
        ${get_response}=    Http Get    ${presigned_url}
        Log To Console    Elapsed: ${timediff} - Response OK (iteration ${i+1})
    EXCEPT
        Log To Console    Elapsed: ${timediff} - Response FAIL (iteration ${i+1})
    END
END
```