### PR TITLE
Add error when publishing to PyPI off `master` branch

### DIFF
--- a/invocations/errors.py
+++ b/invocations/errors.py
@@ -1,0 +1,23 @@
+"""Custom error types used by the invocations package"""
+from invoke import Context, ParseError
+
+
+class RpaInvokeError(Exception):
+    """Unspecified error from rpaframework invocations."""
+
+    pass
+
+
+class WrongBranchError(RpaInvokeError, ParseError):
+    """Raised when an operation is attempted on the incorrect git
+    branch.
+    """
+
+    def __init__(
+        self, current_branch: str, expected_branch: str, context: Context = None
+    ) -> None:
+
+        self.current_branch = current_branch
+        self.expected_branch = expected_branch
+        self.message = f"On branch '{self.current_branch}' but expected branch '{self.expected_branch}'"
+        super().__init__(self.message, context=context)


### PR DESCRIPTION
Also create new customer `errors.py` file for local package error types.

If you attempt to `invoke build.publish` when your branch is not `master`, it will fail and return an error. The `master` branch can be configured with an invoke configuration if needed, but defaults to `master`.