### PR TITLE
`RPA.Database` - add support for mysql ssl configuration

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -7,7 +7,8 @@ Release notes
 
 - Library **RPA.Outlook.Application** (:pr:`666`): Add parameter ``save_as_draft`` parameter 
   to ``Send Message`` / ``Send Email`` keywords. Will save the email instead of sending.
-  
+- Library **RPA.Database** (:pr:`667`): Add SSL support for MySQL modules (``pymysql`` and
+  ``mysql.connector``). 
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Database.py
+++ b/packages/main/src/RPA/Database.py
@@ -192,6 +192,28 @@ class Database:
     ) -> None:
         """Connect to database using DB API 2.0 module.
 
+        **Note.** The SSL support had been added for `mysql`
+        module in `rpaframework==17.7.0`. The extra configuration
+        parameters can be given via configuration file. Extra
+        parameters are:
+
+        - ssl_ca
+        - ssl_cert
+        - ssl_key
+        - client_flags
+
+        Example configuration file:
+
+        .. code-block:: none
+
+            [default]
+            host=hostname.mysql.database.azure.com
+            port=3306
+            username=username@hostname
+            database=databasename
+            client_flags=SSL,FOUND_ROWS
+            ssl_ca=.\DigiCertGlobalRootG2.crt.pem
+
         :param module_name: database module to use
         :param database: name of the database
         :param username: of the user accessing the database
@@ -208,6 +230,12 @@ class Database:
 
             Connect To Database  pymysql  database  username  password  host  port
             Connect To Database  ${CURDIR}${/}resources${/}dbconfig.cfg
+
+            ${secrets}=    Get Secret    azuredb
+            Connect To Database
+            ...    mysql.connector
+            ...    password=${secrets}[password]
+            ...    config_file=${CURDIR}${/}azure.cfg
 
         """
         # TODO. take autocommit into use for all database modules

--- a/packages/main/src/RPA/Database.py
+++ b/packages/main/src/RPA/Database.py
@@ -212,7 +212,7 @@ class Database:
             username=username@hostname
             database=databasename
             client_flags=SSL,FOUND_ROWS
-            ssl_ca=.\DigiCertGlobalRootG2.crt.pem
+            ssl_ca=DigiCertGlobalRootG2.crt.pem
 
         :param module_name: database module to use
         :param database: name of the database

--- a/packages/main/src/RPA/Database.py
+++ b/packages/main/src/RPA/Database.py
@@ -1,6 +1,6 @@
 import importlib
 import logging
-from sqlite3 import NotSupportedError
+
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -728,7 +728,7 @@ class Database:
     def _set_mysql_client_flags(self, module_name, parameters):
         client_flags = self.config.get("client_flags")
         if module_name == "MySQLdb":
-            raise NotSupportedError(
+            raise NotImplementedError(
                 "Setting client_flags for MySQLdb module is not supported"
             )
         if client_flags:


### PR DESCRIPTION
Has been tested with MySQL database modules `pymysql` and `mysql.connector`, which can be installed by following the **conda.yaml**.

The configuration has been slightly updated so that all configuration keys are read from the config file, but their usage still depends on the database module. 

The SSL related configuration settings for the MySQL need to be given through config file. The keyword parameter support has not been extended in this pull request (see the example Robot and config file). 

The config file keys can be overriden by the keyword parameters (those that exist).

```yaml
channels:
  - conda-forge

dependencies:
  - python=3.9.13               # https://pyreadiness.org/3.9/ 
  - pip=22.1.2                  # https://pip.pypa.io/en/stable/news/
  - pip:
      # Define pip packages here -> https://pypi.org/
      - rpaframework==17.7.0    # https://rpaframework.org/releasenotes.html
      - mysql-connector-python==8.0.31
      - pymysql==1.0.2
```

The Robot Framework example
```robotframework
*** Settings ***
Library     RPA.Robocorp.Vault
Library     RPA.Database


*** Tasks ***
Connect To Database Using mysql.connector
    ${secrets}=    Get Secret    azuredb
    Connect To Database 
    ...    mysql.connector   
    ...    password=${secrets}[password]
    ...    config_file=${CURDIR}${/}azure.cfg

Connect To Database Using pymysql 
    ${secrets}=    Get Secret    azuredb
    Connect To Database 
    ...    pymysql 
    ...    password=${secrets}[password]
    ...    config_file=${CURDIR}${/}azure.cfg
```

The example azure.cfg
```config
[default]
host=rpa-mysql-test.mysql.database.azure.com
port=3306
username=rpaadmin@rpa-mysql-test
database=rpa
client_flags=SSL,FOUND_ROWS
ssl_ca=.\DigiCertGlobalRootG2.crt.pem

```