### PR TITLE
Various `RPA.Windows` fixes

### DIFF
--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -102,8 +102,8 @@ class WindowsElement:
                 strategy_regex = strategy
             if strategy_regex.search(last_locator_part):
                 cmp_attrs.append(attr_or_func)
-        # Name is assumed by default if no strategies are found at all.
-        cmp_attrs = cmp_attrs or [self._WINDOW_SIBLING_COMPARE["name"]]
+        # Name comparison is assumed by default if no strategies are found at all.
+        cmp_attrs = cmp_attrs or ["name"]
         for attr_or_func in cmp_attrs:
             if isinstance(attr_or_func, str):
                 status = getattr(self, attr_or_func) == getattr(win_elem, attr_or_func)

--- a/packages/windows/src/RPA/Windows/keywords/action.py
+++ b/packages/windows/src/RPA/Windows/keywords/action.py
@@ -282,7 +282,7 @@ class ActionKeywords(LibraryContext):
         )
 
     @keyword(tags=["action"])
-    def get_value(self, locator: Locator) -> str:
+    def get_value(self, locator: Locator) -> Optional[str]:
         """Get value of the element defined by the locator.
 
         Exception ``ActionNotPossible`` is raised if element does not
@@ -300,7 +300,8 @@ class ActionKeywords(LibraryContext):
         element = self.ctx.get_element(locator)
         if hasattr(element.item, "GetValuePattern"):
             value_pattern = element.item.GetValuePattern()
-            return value_pattern.Value
+            return value_pattern.Value if value_pattern else None
+
         raise ActionNotPossible(
             f"Element found with {locator!r} does not have 'GetValuePattern' attribute"
         )


### PR DESCRIPTION
### ToDo
- [x] `Get Value` returns None when there's no pattern
- [x] Fix siblings searching when there's no comparison strategy identified with `Get Elements`
- [ ] `Get Elements   all=${True}`: https://github.com/robocorp/rpaframework/issues/626
- [ ] Depth: https://github.com/robocorp/rpaframework/issues/371