### PR TITLE
`RPA.HTTP` - Add `Check Vulnerabilities` keyword

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,6 +5,10 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.HTTP** (:pr:`685`): Add keyword ``Check Vulnerabilities`` which will now just
+  check for ``OpenSSL`` vulnerable versions. 
+
+  Related article: https://robocorp.com/docs/faq/openssl-cve-2022-11-01
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/HTTP.py
+++ b/packages/main/src/RPA/HTTP.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 import re
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, List
 from urllib.parse import urlparse
 
 import RequestsLibrary.log
@@ -260,7 +260,7 @@ class HTTP(RequestsLibrary):
 
         return response
 
-    def check_vulnerabilities(self):
+    def check_vulnerabilities(self) -> List:
         """Check for possible Python vulnerabilities in the installed
         runtime environment packages.
 
@@ -268,13 +268,26 @@ class HTTP(RequestsLibrary):
         discovered vulnerability.
 
         :return: list of all check results
+
+        .. code-block:: robotframework
+
+            *** Tasks ***
+            Vulnerability Check
+                ${results}=    Check Vulnerabilities
+                FOR    ${result}    IN    @{results}
+                    Log To Console    TYPE: ${result}[type]
+                    Log To Console    VULNERABLE: ${result}[vulnerable]
+                    Log To Console    MESSAGE: ${result}[message]
+                END
         """
-        all_messages = []
+        all_results = []
         vulnerable, message = self._check_openssl_vulnerabilities()
-        all_messages.append(message)
+        all_results.append(
+            {"type": "OpenSSL", "vulnerable": vulnerable, "message": message}
+        )
         if vulnerable:
             self.logger.warning(message)
-        return all_messages
+        return all_results
 
     def _check_openssl_vulnerabilities(self):
         message = "No OpenSSL detected"

--- a/packages/main/src/RPA/HTTP.py
+++ b/packages/main/src/RPA/HTTP.py
@@ -261,8 +261,8 @@ class HTTP(RequestsLibrary):
         return response
 
     def check_vulnerabilities(self) -> List:
-        """Check for possible Python vulnerabilities in the installed
-        runtime environment packages.
+        """Check for possible vulnerabilities in the installed runtime
+        environment packages.
 
         Currently will check only for OpenSSL version and outputs warning message on any
         discovered vulnerability.

--- a/packages/main/src/RPA/HTTP.py
+++ b/packages/main/src/RPA/HTTP.py
@@ -301,7 +301,7 @@ class HTTP(RequestsLibrary):
                 major, minor, fix = [int(val) for val in open_ssl_version.groups()]
                 if major == 3 and minor == 0 and (0 <= fix <= 6):
                     return True, (
-                        rf"Dependency with HIGH severity vulnerability detected: '{ssl.OPENSSL_VERSION}'.\n"  # noqa: E501
+                        rf"Dependency with HIGH severity vulnerability detected: '{ssl.OPENSSL_VERSION}'. "  # noqa: E501
                         "For more information see https://robocorp.com/docs/faq/openssl-cve-2022-11-01"  # noqa: E501
                     )
             message = ssl.OPENSSL_VERSION


### PR DESCRIPTION
The keyword will check if the installed OpenSSL version is within the range of 3.0.0 - 3.0.6 and outputs a warning message in this case.

Outputs all results as a list of dictionaries containing type, vulnerable status (True if there are issues) and the message (if in the future additional checks would be made those will be included in the same list).

usage example in Robot Framework
```robotframework
${results}=    Check Vulnerabilities
FOR    ${result}    IN    @{results}
    Log To Console    TYPE: ${result}[type]
    Log To Console    VULNERABLE: ${result}[vulnerable]
    Log To Console    MESSAGE: ${result}[message]
END
```

example output from the above code, with GOOD OpenSSL version
```bash
TYPE: OpenSSL
VULNERABLE: False
MESSAGE: OpenSSL 1.1.1n  15 Mar 2022
```

example warning message and the output from the above code, with **VULNERABLE** OpenSSL version
`[ WARN ] Dependency with HIGH severity vulnerability detected: 'OpenSSL 3.0.5 5 Jul 2022'. For more information see https://robocorp.com/docs/faq/openssl-cve-2022-11-01`
```bash
TYPE: OpenSSL
VULNERABLE: True
MESSAGE: Dependency with HIGH severity vulnerability detected: 'OpenSSL 3.0.5 5 Jul 2022'. For more information see https://robocorp.com/docs/faq/openssl-cve-2022-11-01
```