### PR TITLE
Reorder imports so `win32api` is imported before `pywintypes`

### DIFF
--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "19.1.1a1"
+version = "19.1.1a2"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "19.1.0"
+version = "19.1.1a1"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -12,8 +12,8 @@ from RPA.Email.common import counter_duplicate_path
 
 if platform.system() == "Windows":
     import win32api
-    import pywintypes
     import win32com.client
+    import pywintypes
 else:
     logging.getLogger(__name__).warning(
         "RPA.Outlook.Application library works only on Windows platform"

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -11,8 +11,8 @@ from typing import Any, List
 from RPA.Email.common import counter_duplicate_path
 
 if platform.system() == "Windows":
-    import pywintypes
     import win32api
+    import pywintypes
     import win32com.client
 else:
     logging.getLogger(__name__).warning(


### PR DESCRIPTION
This resolves an import error related to `pywintypes39.dll`