### PR TITLE
`RPA.Slack`.  Add blocks property support for messages

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,6 +5,8 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.Slack** (:issue:`711`): New keyword ``Slack Raw Message`` adds support for 
+  ``blocks`` message property by allowing user to set message dictionary.
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Slack.py
+++ b/packages/main/src/RPA/Slack.py
@@ -42,24 +42,22 @@ class Slack:
 
     def slack_raw_message(
         self,
-        webhook_url: str,
-        json_data: Union[str, dict],
+        webhook: str,
+        message: Union[str, dict],
         channel: Optional[str] = None,
     ):
         """Send Slack message by custom JSON content.
 
         :param webhook_url: needs to be configured for the Slack server
-        :param json_data: dictionary defining message content and structure
+        :param message: dictionary or string defining message content and structure
         :param channel: can be used to set channel into message structure
         """
         headers = {"Content-Type": "application/json"}
-        if channel and isinstance(json_data, dict):
-            json_data["channel"] = channel
+        if channel and isinstance(message, dict):
+            message["channel"] = channel
         elif channel:
             self.logger.warning("Can't set channel as 'json_data' is a string.")
             return
-        data_for_message = (
-            json_data if isinstance(json_data, str) else json.dumps(json_data)
-        )
-        response = requests.post(webhook_url, headers=headers, data=data_for_message)
+        data_for_message = message if isinstance(message, str) else json.dumps(message)
+        response = requests.post(webhook, headers=headers, data=data_for_message)
         self.logger.debug(response.status_code)

--- a/packages/main/src/RPA/Slack.py
+++ b/packages/main/src/RPA/Slack.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional, Union
 import requests
 
 
@@ -18,7 +19,7 @@ class Slack:
         channel: str,
         sender: str,
         text: str,
-        icon_emoji: str = None,
+        icon_emoji: Optional[str] = None,
     ):
         """Send message to Slack channel using webhook.
 
@@ -37,4 +38,28 @@ class Slack:
         if icon_emoji:
             payload["icon_emoji"] = icon_emoji
         response = requests.post(webhook_url, headers=headers, data=json.dumps(payload))
+        self.logger.debug(response.status_code)
+
+    def slack_raw_message(
+        self,
+        webhook_url: str,
+        json_data: Union[str, dict],
+        channel: Optional[str] = None,
+    ):
+        """Send Slack message by custom JSON content.
+
+        :param webhook_url: needs to be configured for the Slack server
+        :param json_data: dictionary defining message content and structure
+        :param channel: can be used to set channel into message structure
+        """
+        headers = {"Content-Type": "application/json"}
+        if channel and isinstance(json_data, dict):
+            json_data["channel"] = channel
+        elif channel:
+            self.logger.warning("Can't set channel as 'json_data' is a string.")
+            return
+        data_for_message = (
+            json_data if isinstance(json_data, str) else json.dumps(json_data)
+        )
+        response = requests.post(webhook_url, headers=headers, data=data_for_message)
         self.logger.debug(response.status_code)


### PR DESCRIPTION
Robot Framework usage example - channel set or overriding channel in the ${MESSAGE}
```robotframework
Slack Raw Message    webhook=${WEBHOOK}    message=${MESSAGE}    channel=general
```

Robot Framework usage example - channel included in the ${MESSAGE} dictionary
```robotframework
Slack Raw Message    webhook=${WEBHOOK}    message=${MESSAGE}
```