### PR TITLE
Feature/windows locator props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ poetry.toml
 # VS Code
 .vscode/
 
+# PyCharm
+.idea/
+
 # MacOS
 .DS_Store
 

--- a/packages/core/src/RPA/core/windows/locators.py
+++ b/packages/core/src/RPA/core/windows/locators.py
@@ -295,6 +295,10 @@ class LocatorMethods(WindowsContext):
                 search_params, param_type="handle", win_type="handle"
             )
 
+        control = self._get_control_from_params(search_params)
+        if auto.ControlsAreSame(control, root_control):
+            return Control.CreateControlFromControl(root_control)
+
         return self._get_control_from_params(search_params, root_control=root_control)
 
     def _load_by_alias(self, criteria: str) -> str:


### PR DESCRIPTION
* Add lists of Windows control properties (top control, parent control, and current control) to inspect_element recordings
* Allow Windows locators to contain the anchor locator even if the contained locator is used as a root_control 