### PR TITLE
SAP. Fix order of imports

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,6 +5,7 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.SAP**: Fix error in dependency import order in underlying SapGuiLibrary
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/SAP.py
+++ b/packages/main/src/RPA/SAP.py
@@ -7,6 +7,9 @@ from comtypes import COMError
 
 
 if platform.system() == "Windows":
+    # import win32com.client to fix order of imports in the SapGuiLibrary
+    # pylint: disable=unused-import
+    import win32com.client  # noqa: F401
     from SapGuiLibrary import SapGuiLibrary
 else:
     logging.getLogger(__name__).warning(


### PR DESCRIPTION
The underlying SAP package imports `pythoncom` before `win32com.client` which can break the dependency resolution.

Fixed by importing `win32com.client` in the `RPA.SAP` before importing `sapguilibrary`

```python
if platform.system() == "Windows":
    # import win32com.client to fix order of imports in the SapGuiLibrary
    # pylint: disable=unused-import
    import win32com.client  # noqa: F401
    from SapGuiLibrary import SapGuiLibrary
```