### PR TITLE
Fix semantic versioning break

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "10.1.2"
+version = "10.2.0"
 description = "Core utilities used by RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "10.1.1"
+version = "10.1.2"
 description = "Core utilities used by RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -50,24 +50,33 @@ _DRIVER_PREFERENCE = {
 }
 
 
+def _get_browser_order_from_env() -> Optional[List[str]]:
+    browsers: str = os.getenv("RPA_SELENIUM_BROWSER_ORDER", "")
+    if browsers:
+        return [browser.strip() for browser in browsers.split(sep=",")]
+
+    return None  # meaning there's no env var to control the order
+
+
 def get_browser_order() -> List[str]:
     """Get a list of preferred browsers based on the environment variable
     `RPA_SELENIUM_BROWSER_ORDER` if set.
 
     The OS dictates the order if no such env var is set.
     """
-    browsers: str = os.getenv("RPA_SELENIUM_BROWSER_ORDER", "")
+    browsers: Optional[List[str]] = _get_browser_order_from_env()
     if browsers:
-        return [browser.strip() for browser in browsers.split(sep=",")]
+        return browsers
 
     return _DRIVER_PREFERENCE.get(platform.system(), _DRIVER_PREFERENCE["default"])
 
 
 def _set_driver_preference() -> Dict[str, List[str]]:
     pref = _DRIVER_PREFERENCE.copy()
-    browsers = get_browser_order()
-    for os in pref:
-        pref[os] = browsers
+    browsers: Optional[List[str]] = _get_browser_order_from_env()
+    if browsers:
+        for os in pref:
+            pref[os] = browsers
     return pref
 
 

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -43,6 +43,17 @@ AVAILABLE_DRIVERS = {
     "ie": IEDriverManager,
 }
 
+# Note: This is depracated.
+# Current resolving logic contained in RPA.Browser.Selenium,
+# and this should not be used anymore, but removing this
+# must be done in a major version.
+DRIVER_PREFERENCE = {
+    "Windows": ["Chrome", "Firefox", "ChromiumEdge"],
+    "Linux": ["Chrome", "Firefox", "ChromiumEdge"],
+    "Darwin": ["Chrome", "Firefox", "ChromiumEdge", "Safari"],
+    "default": ["Chrome", "Firefox"],
+}
+
 
 class Downloader(WDMHttpClient):
 

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -4,7 +4,7 @@ import os
 import platform
 import stat
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import requests
 from packaging import version
@@ -43,16 +43,26 @@ AVAILABLE_DRIVERS = {
     "ie": IEDriverManager,
 }
 
-# Note: This is depracated.
-# Current resolving logic contained in RPA.Browser.Selenium,
-# and this should not be used anymore, but removing this
-# must be done in a major version.
-DRIVER_PREFERENCE = {
-    "Windows": ["Chrome", "Firefox", "ChromiumEdge"],
-    "Linux": ["Chrome", "Firefox", "ChromiumEdge"],
-    "Darwin": ["Chrome", "Firefox", "ChromiumEdge", "Safari"],
-    "default": ["Chrome", "Firefox"],
-}
+
+def _browser_preferences() -> Dict[str, List[str]]:
+    """Get a list of preferred browsers to use given the OS.
+
+    Environment variable `RPA_SELENIUM_BROWSER_ORDER` takes precedence if defined.
+    """
+    preferences = {
+        "Windows": ["Chrome", "Firefox", "ChromiumEdge"],
+        "Linux": ["Chrome", "Firefox", "ChromiumEdge"],
+        "Darwin": ["Chrome", "Firefox", "ChromiumEdge", "Safari"],
+        "default": ["Chrome", "Firefox"],
+    }
+    browsers = os.getenv("RPA_SELENIUM_BROWSER_ORDER", "")
+    if browsers:
+        preferences["custom"] = [browser.strip() for browser in browsers.split(sep=",")]
+
+    return preferences
+
+
+DRIVER_PREFERENCE = _browser_preferences()
 
 
 class Downloader(WDMHttpClient):


### PR DESCRIPTION
Core `10.1.1` removed a property that was referenced in `RPA.Browser.Selenium`, however old versions of `rpaframework` only pinned the major version for core. The previous version was yanked, and this will restore compatiblity if released.

Not tested, since I am unable to run the new invocations on my machine, and too busy to debug 😇 
Please make sure I didn't typo anything in the revert.