### PR TITLE
RPA.Assistant doesn't have keywords used in example

### DIFF
--- a/packages/assistant/src/RPA/Assistant/library.py
+++ b/packages/assistant/src/RPA/Assistant/library.py
@@ -134,12 +134,6 @@ class Assistant:
             ...    rows=5
             ${result}=    Run dialog
             Send feedback message    ${result.email}  ${result.message}
-
-        Dialog as progress indicator
-            Add heading    Please wait while I open a browser
-            ${dialog}=     Show dialog    title=Please wait    on_top=${TRUE}
-            Open available browser    https://robocorp.com
-            Close dialog   ${dialog}
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
`Show dialog` and `Close dialog` keywords are not in the library