### PR TITLE
RPA.Database : Fix psycopg2 module error

### DIFF
--- a/packages/main/src/RPA/Database.py
+++ b/packages/main/src/RPA/Database.py
@@ -410,7 +410,7 @@ class Database:
         params = params or []
         cur = None
         try:
-            if self.db_api_module_name in ("cx_Oracle", "oracledb"):
+            if self.db_api_module_name in ("cx_Oracle", "oracledb", "psycopg2"):
                 cur = self._dbconnection.cursor()
             else:
                 cur = self._dbconnection.cursor(as_dict=False)


### PR DESCRIPTION
The following error occurs in RPA.Database while calling a stored procedure using the psycopg2 module:

`[FAIL] TypeError: 'as_dict' is an invalid keyword argument for this function`

Several modules ("cx_Oracle", "oracledb") are already excluded from this. This PR simply adds psycopg2 to the list.

For reference my dependencies are:
rpaframework==22.0.0
psycopg2-binary==2.9.5