### PR TITLE
Close RPA.Email.ImapSmtp Send Message should not require recipients #454

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,8 +5,12 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-- Library **RPA.FTP** (:pr:`938`): Add socket support for TLS connections.
+- Library **RPA.Email.ImapSmtp**:
 
+  - Make the `recipients` optional. It is still mandatory to give one of the following
+    parameters `recipients`, `cc` or `bcc`. (:pr:`930`)
+
+- Library **RPA.FTP** (:pr:`938`): Add socket support for TLS connections.
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/src/RPA/Email/Exchange.py
+++ b/packages/main/src/RPA/Email/Exchange.py
@@ -35,6 +35,7 @@ from RPA.Email.common import (
     OAuthMixin,
     OAuthProvider,
     counter_duplicate_path,
+    NoRecipientsError,
 )
 from RPA.Robocorp.Vault import Vault
 from RPA.Robocorp.utils import protect_keywords
@@ -73,9 +74,6 @@ class AccessType(Enum):
     DELEGATE = DELEGATE
     IMPERSONATION = IMPERSONATION
 
-
-class NoRecipientsError(ValueError):
-    """Raised when email to be sent does not have any recipients, cc or bcc addresses."""  # noqa: E501
 
 
 class OAuth2Creds(OAuth2AuthorizationCodeCredentials):

--- a/packages/main/src/RPA/Email/Exchange.py
+++ b/packages/main/src/RPA/Email/Exchange.py
@@ -75,7 +75,6 @@ class AccessType(Enum):
     IMPERSONATION = IMPERSONATION
 
 
-
 class OAuth2Creds(OAuth2AuthorizationCodeCredentials):
 
     """OAuth2 auth code flow credentials wrapper supporting token state on refresh."""

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -39,6 +39,7 @@ from RPA.Email.common import (
     counter_duplicate_path,
 )
 from RPA.Robocorp.utils import protect_keywords
+from RPA.Email.Exchange import NoRecipientsError
 
 
 FilePath = Union[str, Path]
@@ -449,7 +450,7 @@ class ImapSmtp(OAuthMixin):
     def send_message(
         self,
         sender: str,
-        recipients: Union[List[str], str],
+        recipients: Union[List[str], str] = [],
         subject: str = "",
         body: str = "",
         attachments: Optional[Union[List[str], str]] = None,
@@ -521,6 +522,10 @@ class ImapSmtp(OAuthMixin):
 
         if evaluated_attachment_position == AttachmentPosition.BOTTOM:
             self._add_attachments_to_msg(attachments, msg)
+
+        if not recipients:
+            raise NoRecipientsError()
+            return False
 
         # Create a generator and flatten message object to 'file’
         str_io = StringIO()

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -37,9 +37,9 @@ from RPA.Email.common import (
     OAuthProvider,
     OAuthProviderType,
     counter_duplicate_path,
+    NoRecipientsError
 )
 from RPA.Robocorp.utils import protect_keywords
-from RPA.Email.Exchange import NoRecipientsError
 
 
 FilePath = Union[str, Path]
@@ -450,7 +450,7 @@ class ImapSmtp(OAuthMixin):
     def send_message(
         self,
         sender: str,
-        recipients: Union[List[str], str] = [],
+        recipients: Optional[Union[List[str], str]] = None,
         subject: str = "",
         body: str = "",
         attachments: Optional[Union[List[str], str]] = None,
@@ -498,7 +498,7 @@ class ImapSmtp(OAuthMixin):
         """
         evaluated_attachment_position = to_attachment_position(attachment_position)
         add_charset(self.encoding, QP, QP, self.encoding)
-        to, attachments, images = self._handle_message_parameters(
+        email_recipients, attachments, images = self._handle_message_parameters(
             recipients, attachments, images
         )
         msg = MIMEMultipart()
@@ -507,25 +507,23 @@ class ImapSmtp(OAuthMixin):
             self._add_attachments_to_msg(attachments, msg)
 
         sender = sender.encode("idna").decode("ascii")
-        msg_to = ",".join(to).encode("idna").decode("ascii")
         msg["From"] = sender
-        msg["To"] = msg_to
+        msg["To"] = ",".join(email_recipients).encode("idna").decode("ascii")
         msg["Subject"] = Header(subject, self.encoding)
-        recipients = to if isinstance(to, list) else [to]
+
         if cc:
             msg["Cc"] = ",".join(cc) if isinstance(cc, list) else cc
-            recipients += cc if isinstance(cc, list) else cc.split(",")
+            email_recipients += cc if isinstance(cc, list) else cc.split(",")
         if bcc:
-            recipients += bcc if isinstance(bcc, list) else bcc.split(",")
+            email_recipients += bcc if isinstance(bcc, list) else bcc.split(",")
+
+        if not email_recipients:
+            raise NoRecipientsError("Message needs to have either 'recipients', 'cc' or 'bcc' for sending.")
 
         self._add_message_content(html, images, body, msg)
 
         if evaluated_attachment_position == AttachmentPosition.BOTTOM:
             self._add_attachments_to_msg(attachments, msg)
-
-        if not recipients:
-            raise NoRecipientsError()
-            return False
 
         # Create a generator and flatten message object to 'file’
         str_io = StringIO()
@@ -534,7 +532,7 @@ class ImapSmtp(OAuthMixin):
         try:
             if self.smtp_conn is None:
                 self.authorize_smtp()
-            self.smtp_conn.sendmail(sender, recipients, str_io.getvalue())
+            self.smtp_conn.sendmail(sender, email_recipients, str_io.getvalue())
         except Exception as err:
             raise ValueError(f"Send Message failed: {err}") from err
         return True
@@ -570,6 +568,8 @@ class ImapSmtp(OAuthMixin):
             attachments = []
         if images is None:
             images = []
+        if recipients is None:
+            recipients = []
         if not isinstance(recipients, list):
             recipients = recipients.split(",")
         if not isinstance(attachments, list):

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -37,7 +37,7 @@ from RPA.Email.common import (
     OAuthProvider,
     OAuthProviderType,
     counter_duplicate_path,
-    NoRecipientsError
+    NoRecipientsError,
 )
 from RPA.Robocorp.utils import protect_keywords
 
@@ -518,7 +518,9 @@ class ImapSmtp(OAuthMixin):
             email_recipients += bcc if isinstance(bcc, list) else bcc.split(",")
 
         if not email_recipients:
-            raise NoRecipientsError("Message needs to have either 'recipients', 'cc' or 'bcc' for sending.")
+            raise NoRecipientsError(
+                "Message needs to have either 'recipients', 'cc' or 'bcc' for sending."
+            )
 
         self._add_message_content(html, images, body, msg)
 

--- a/packages/main/src/RPA/Email/common.py
+++ b/packages/main/src/RPA/Email/common.py
@@ -17,6 +17,10 @@ lib_mfa = MFA()
 OAuthProviderType = Union["OAuthProvider", str]
 
 
+class NoRecipientsError(ValueError):
+    """Raised when email to be sent does not have any recipients, cc or bcc addresses."""  # noqa: E501
+
+
 class OAuthProvider(Enum):
     """OAuth2 tested providers."""
 

--- a/packages/main/tests/python/test_imapsmtp.py
+++ b/packages/main/tests/python/test_imapsmtp.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 from RPA.Email.ImapSmtp import ImapSmtp
-from RPA.Email.common import counter_duplicate_path
+from RPA.Email.common import counter_duplicate_path, NoRecipientsError
 from docx import Document
 
 from . import RESOURCES_DIR
@@ -65,7 +65,7 @@ def test_send_message_with_no_sender(library, recipients):
 
 
 def test_send_message_with_no_recipients(library):
-    with pytest.raises(TypeError):
+    with pytest.raises(NoRecipientsError):
         library.send_message(
             sender="sender@domain.com",
             subject="My test email subject",


### PR DESCRIPTION
I gave the recipients a default value of an empty list so it is not required.

I checked if the recipients is empty after everything e.g cc and bcc have been added to it.