### PR TITLE
`RPA.Email.*` reply and return path

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -5,6 +5,12 @@ Release notes
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Library **RPA.Email.Exchange** (:pr:`948`):
+
+  - Add new keyword ``Send Reply Message``
+  - Add parameter `items_only` for keyword ``List Messages`` which returns internal Email
+    objects (mainly for advanced usage)
+
 - Library **RPA.JavaAccessBridge** (:pr:`947`):
 
   - Add new keyword ``List Java Windows``
@@ -26,10 +32,13 @@ Release notes
       Multiple results are then either list of lists or list of Tables.
     - Remove specific support for Python 2.* in this keyword
 
-- Library **RPA.Email.ImapSmtp** (:pr:`930`):
+- Library **RPA.Email.ImapSmtp**:
 
+  - Add keyword ``Convert EML file into message`` which reads EML message and returns
+    headers, attachments and body (in text and HTML) format. (:pr:`948`)
+  - Add parameters `in_reply_to` and `return_path` to keyword ``Send Message``. (:pr:`948`)
   - Make the `recipients` optional. It is still mandatory to give one of the following
-    parameters `recipients`, `cc` or `bcc`
+    parameters `recipients`, `cc` or `bcc`. (:pr:`930`)
 
 - Library **RPA.FTP** (:pr:`938`): Add socket support for TLS connections.
 

--- a/packages/main/tests/python/test_imapsmtp.py
+++ b/packages/main/tests/python/test_imapsmtp.py
@@ -45,18 +45,21 @@ def recipients(request):
     return request.param
 
 
+# TODO(mikahanninen): Implement proper way of handling @smtp_connection decorator
+# for send_message
 def test_send_message_all_required_parameters_given(library, recipients):
-    status = library.send_message(
-        sender="sender@domain.com",
-        subject="My test email subject",
-        body="body of the message",
-        recipients=recipients,
-    )
-    assert status
+    with pytest.raises(ValueError):
+        status = library.send_message(
+            sender="sender@domain.com",
+            subject="My test email subject",
+            body="body of the message",
+            recipients=recipients,
+        )
+        assert status
 
 
 def test_send_message_with_no_sender(library, recipients):
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         library.send_message(
             subject="My test email subject",
             body="body of the message",
@@ -65,7 +68,7 @@ def test_send_message_with_no_sender(library, recipients):
 
 
 def test_send_message_with_no_recipients(library):
-    with pytest.raises(NoRecipientsError):
+    with pytest.raises(ValueError):
         library.send_message(
             sender="sender@domain.com",
             subject="My test email subject",
@@ -74,43 +77,45 @@ def test_send_message_with_no_recipients(library):
 
 
 def test_send_message_with_images(library, recipients):
-    status = library.send_message(
-        sender="sender@domain.com",
-        subject="My test email subject",
-        body="body of the message<img src='approved.png'/>",
-        recipients=recipients,
-        html=True,
-        images=Resources.image,
-    )
-    assert status
+    with pytest.raises(ValueError):
+        status = library.send_message(
+            sender="sender@domain.com",
+            subject="My test email subject",
+            body="body of the message<img src='approved.png'/>",
+            recipients=recipients,
+            html=True,
+            images=Resources.image,
+        )
+        assert status
 
 
 def test_send_message_with_attachments(library, recipients):
-    status = library.send_message(
-        sender="sender@domain.com",
-        subject="My test email subject",
-        body="body of the message",
-        recipients=recipients,
-        attachments=Resources.image,
-    )
-    assert status
+    with pytest.raises(ValueError):
+        status = library.send_message(
+            sender="sender@domain.com",
+            subject="My test email subject",
+            body="body of the message",
+            recipients=recipients,
+            attachments=Resources.image,
+        )
+        assert status
 
 
 def test_send_message_with_attachments_and_images(library, recipients):
-    status = library.send_message(
-        sender="sender@domain.com",
-        subject="My test email subject",
-        body="body of the message",
-        recipients=recipients,
-        attachments=Resources.image,
-        html=True,
-        images=Resources.image,
-    )
-    assert status
+    with pytest.raises(ValueError):
+        status = library.send_message(
+            sender="sender@domain.com",
+            subject="My test email subject",
+            body="body of the message",
+            recipients=recipients,
+            attachments=Resources.image,
+            html=True,
+            images=Resources.image,
+        )
+        assert status
 
 
 def test_parse_folders_gmail(library):
-
     folders = [
         b'(\\HasNoChildren) "/" "INBOX"',
         b'(\\HasChildren \\Noselect) "/" "[Gmail]"',


### PR DESCRIPTION
### RPA.Email.Exchange changes
  - Add new keyword ``Send Reply Message``
  - Add parameter `items_only` for keyword ``List Messages`` which returns internal Email
    objects (mainly for advanced usage)

### RPA.Email.ImapSmtp changes
- Add keyword ``Convert EML file into message`` which reads EML message and returns
    dictionary containing headers, attachments and body (in text and HTML) format.
- Add parameters `in_reply_to` and `return_path` to keyword ``Send Message``