### PR TITLE
`RPA.JavaAccessBridge`. wrapper update

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -9,12 +9,20 @@ Release notes
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+23.5.1 - 28 Jun 2023
+--------------------
+
+- Library **RPA.JavaAccessBridge**:
+
+  - Update and pin ``java-access-bridge-wrapper`` to version ``0.14.1``
+
 23.5.0 - 27 Jun 2023
 --------------------
 
 - Library **RPA.JavaAccessBridge**:
 
   - Update ``java-access-bridge-wrapper`` to version ``0.13.0``
+  - Add keyword ``Print Locator Tree``
 
 
 23.4.0 - 22 Jun 2023

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -1053,14 +1053,14 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 
 [[package]]
 name = "java-access-bridge-wrapper"
-version = "0.13.0"
+version = "0.14.1"
 description = "Python wrapper for the Windows Java Access Bridge"
 category = "main"
 optional = false
 python-versions = ">=3.6.2,<4.0.0"
 files = [
-    {file = "java_access_bridge_wrapper-0.13.0-py3-none-any.whl", hash = "sha256:0eec4f507ee11453a6f5dbd883ecf4252d2b46bb03035046def0de3ab37653d2"},
-    {file = "java_access_bridge_wrapper-0.13.0.tar.gz", hash = "sha256:7e473e9c2156008b74f9a3c34c0ad5e48ce4e2282e335bce2c9c88422dd9ae10"},
+    {file = "java_access_bridge_wrapper-0.14.1-py3-none-any.whl", hash = "sha256:5e3a5afbb5a42a50d33b355ad74b7fe1e1109c4f7a90c363ec49542fcd605806"},
+    {file = "java_access_bridge_wrapper-0.14.1.tar.gz", hash = "sha256:8ee085b6257b23037e84c0572821e636402b14450ec7d396b0b04ab85ce40476"},
 ]
 
 [package.dependencies]
@@ -2108,14 +2108,14 @@ files = [
 
 [[package]]
 name = "pypdf"
-version = "3.11.0"
+version = "3.11.1"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pypdf-3.11.0-py3-none-any.whl", hash = "sha256:4f1fd2c1ee05e381e05447152d9e993016666647578fcdd7cf15739d13536861"},
-    {file = "pypdf-3.11.0.tar.gz", hash = "sha256:2f5b9b28763234427cd6e525795e583aae7e36a79bdadd48ba8ab5277c12182a"},
+    {file = "pypdf-3.11.1-py3-none-any.whl", hash = "sha256:2afc8914355a784fb184f60ae82fe10f9b992aa0733b705f0746966e470f98bd"},
+    {file = "pypdf-3.11.1.tar.gz", hash = "sha256:198c4d0231525d0b730cbbd11a5fc7d9a2e410dfc8ae2928c8de000b7ef149c5"},
 ]
 
 [package.dependencies]
@@ -3672,4 +3672,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "474e7d7d34053a74a62f1cb9892aff2b556c27644e53e02f8aef2315a9f61fdd"
+content-hash = "63850cc4be282fe2560ca3e8bc8ff3510f1569cdfb0034a5e4fd77c346390b40"

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "23.5.0"
+version = "23.5.1"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"
@@ -38,6 +38,7 @@ docutils = "*"
 rpaframework-core = "^11.0.2"
 rpaframework-pdf = "^7.1.5"
 rpaframework-windows = { version = "^7.3.2", platform = "win32" }
+java-access-bridge-wrapper = "0.14.1"
 robocorp-storage = "^0.1.2"
 jsonpath-ng = "^1.5.2"
 robotframework = ">=4.0.0,!=4.0.1,<6.0.0"
@@ -71,7 +72,6 @@ chardet = "^3.0.0"
 PySocks = ">=1.5.6,!=1.5.7,<2.0.0"
 selenium = "^4.6.1,!=4.10.0"
 click = "^8.1.2"
-java-access-bridge-wrapper = "^0.13.0"
 PyYAML = ">=5.4.1,<7.0.0"
 tenacity = "^8.0.1"
 htmldocx = "^0.0.6"

--- a/packages/main/src/RPA/JavaAccessBridge.py
+++ b/packages/main/src/RPA/JavaAccessBridge.py
@@ -66,6 +66,8 @@ if platform.system() == "Windows":  # noqa: C901
         selected: bool
         visible: bool
         enabled: bool
+        showing: bool
+        focusable: bool
         states_string: str
         x: int
         y: int
@@ -98,6 +100,8 @@ if platform.system() == "Windows":  # noqa: C901
             self.selected = "selected" in self.states
             self.visible = "visible" in self.states
             self.enabled = "enabled" in self.states
+            self.showing = "showing" in self.states
+            self.focusable = "focusable" in self.states
             self.node = node
             self.internal = internal_node
             self.states_string = node.context_info.states
@@ -150,6 +154,8 @@ if platform.system() == "Windows":  # noqa: C901
                 f"visible={self.visible}; "
                 f"selected={self.selected}; "
                 f"checked={self.checked}; "
+                f"showing={self.checked}; "
+                f"focusable={self.checked}; "
                 f"description={self.description}; "
                 f"ancestry={self.ancestry}; "
                 f"states={self.states}; "
@@ -956,6 +962,22 @@ class JavaAccessBridge:
         return tree
 
     @keyword
+    def get_locator_tree(self):
+        """Return Java locator tree as list of objects.
+
+        Mostly relevant object properties are:
+
+            - ancestry
+            - role
+            - name
+            - description
+            - indexInParent
+
+        :return: list of objects
+        """
+        return self.context_info_tree.get_search_element_tree()
+
+    @keyword
     def print_locator_tree(self, filename: str = None):
         """Print current Java window locator list into log and possibly
         into a file.
@@ -963,7 +985,15 @@ class JavaAccessBridge:
         :param filename: filepath to save locator tree
         :return: locator tree
         """
-        tree = self.context_info_tree.get_library_locator_tree_as_text()
+        search_tree = self.get_locator_tree()
+        tree = "\n".join(
+            [
+                f"{'| ' * item.ancestry}role:{item.role} and name:{item.name} and "
+                f"description:{item.description} "
+                f"and indexInParent:{item.indexInParent}"
+                for item in search_tree
+            ]
+        )
         self.logger.info(tree)
         if filename:
             with open(filename, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Pins `java-access-bridge-wrapper==0.14.1` as we need to be certain of the version of the wrapper which the library is using.