### PR TITLE
Add support for Selenium binary location through env var

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -9,13 +9,18 @@ Release notes
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-24.0.1 - 25 Jul 2023
+24.1.0 - 25 Jul 2023
 --------------------
 
 - Library **RPA.Browser.Selenium** (:pr:`1021`; ``rpaframework-core`` **11.0.4**):
-  Correctly handles and downloads a valid webdriver version when there's a need for
-  one. (Portal example:
-  https://robocorp.com/portal/robot/robocorp/example-google-image-search)
+
+  - Correctly handles and downloads a valid existing webdriver version when there's a
+    need for one.
+  - Ability to provide a default browser binary location with the
+    `RPA_SELENIUM_BINARY_LOCATION` environment variable. (useful when the webdriver
+    isn't able to automatically detect and start your system browser)
+  - Portal example taking these into use:
+    https://robocorp.com/portal/robot/robocorp/example-google-image-search
 
 24.0.0 - 18 Jul 2023
 --------------------

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "24.0.1"
+version = "24.1.0"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1108,14 +1108,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.94.0"
+version = "2.95.0"
 description = "Google API Client Library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-python-client-2.94.0.tar.gz", hash = "sha256:4ff598b7b83d5c0c5582927e74947286070b5b21a13e1bb64409fd92e45bfb26"},
-    {file = "google_api_python_client-2.94.0-py2.py3-none-any.whl", hash = "sha256:28b2f0c2c6380a119e2efd7ecd28fa9d313becf37d71f00bfa49332428e071b4"},
+    {file = "google-api-python-client-2.95.0.tar.gz", hash = "sha256:d2731ede12f79e53fbe11fdb913dfe986440b44c0a28431c78a8ec275f4c1541"},
+    {file = "google_api_python_client-2.95.0-py2.py3-none-any.whl", hash = "sha256:a8aab2da678f42a01f2f52108f787fef4310f23f9dd917c4e64664c3f0c885ba"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -4071,7 +4071,7 @@ files = [
 
 [[package]]
 name = "rpaframework"
-version = "24.0.1"
+version = "24.1.0"
 description = "A collection of tools and libraries for RPA"
 category = "main"
 optional = false


### PR DESCRIPTION
Currently this is needed when developing and/or releasing from a Mac, as for some reason here the new **115** Chrome isn't detected automatically by the _chromedriver_ **115**, but it is by _chromedriver_ **114** even when used with the same Chrome 115.