### PR TITLE
Use common `Application` class for library COM apps

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -16,6 +16,34 @@ Latest versions
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+26.0.0 - 18 Aug 2023
+--------------------
+
+- Library **RPA.Browser.Selenium** (:pr:`1058`):
+
+  - Fixed `options` passing with Firefox. (when a binary location is specified)
+
+- General improvements to **RPA.*.Application** libraries (:issue:`1055`):
+
+  - *All*: Better error handling (COM -> runtime), improved generic docs and
+    troubleshooting guiding, fixed document closing (if was closed already) and app
+    open/quit management, improved warnings and logging, file paths are tested for
+    existence when operating on documents and raise errors in their absence.
+
+  - **Excel**:
+
+    - Removed deprecated parameter `tabname` from ``Add New Sheet``. (use `sheetname`)
+    - ``Save Excel As`` raises when there's no workbook open. (use ``Open Workbook``
+      first)
+
+  - **Outlook**:
+
+    - Removed deprecated keywords: ``Send Message`` (use ``Send Email``) and
+      ``Wait For Message`` (use ``Wait For Email``).
+
+  .. warning::
+    **Breaking** changes in the **Application** libraries listed above.
+
 25.0.1 - 11 Aug 2023
 --------------------
 

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -407,72 +407,64 @@ tests = ["coverage"]
 
 [[package]]
 name = "coverage"
-version = "7.2.7"
+version = "7.3.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.2.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d39b5b4f2a66ccae8b7263ac3c8170994b65266797fb96cbbfd3fb5b23921db8"},
-    {file = "coverage-7.2.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6d040ef7c9859bb11dfeb056ff5b3872436e3b5e401817d87a31e1750b9ae2fb"},
-    {file = "coverage-7.2.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba90a9563ba44a72fda2e85302c3abc71c5589cea608ca16c22b9804262aaeb6"},
-    {file = "coverage-7.2.7-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7d9405291c6928619403db1d10bd07888888ec1abcbd9748fdaa971d7d661b2"},
-    {file = "coverage-7.2.7-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31563e97dae5598556600466ad9beea39fb04e0229e61c12eaa206e0aa202063"},
-    {file = "coverage-7.2.7-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ebba1cd308ef115925421d3e6a586e655ca5a77b5bf41e02eb0e4562a111f2d1"},
-    {file = "coverage-7.2.7-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:cb017fd1b2603ef59e374ba2063f593abe0fc45f2ad9abdde5b4d83bd922a353"},
-    {file = "coverage-7.2.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d62a5c7dad11015c66fbb9d881bc4caa5b12f16292f857842d9d1871595f4495"},
-    {file = "coverage-7.2.7-cp310-cp310-win32.whl", hash = "sha256:ee57190f24fba796e36bb6d3aa8a8783c643d8fa9760c89f7a98ab5455fbf818"},
-    {file = "coverage-7.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:f75f7168ab25dd93110c8a8117a22450c19976afbc44234cbf71481094c1b850"},
-    {file = "coverage-7.2.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:06a9a2be0b5b576c3f18f1a241f0473575c4a26021b52b2a85263a00f034d51f"},
-    {file = "coverage-7.2.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5baa06420f837184130752b7c5ea0808762083bf3487b5038d68b012e5937dbe"},
-    {file = "coverage-7.2.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdec9e8cbf13a5bf63290fc6013d216a4c7232efb51548594ca3631a7f13c3a3"},
-    {file = "coverage-7.2.7-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52edc1a60c0d34afa421c9c37078817b2e67a392cab17d97283b64c5833f427f"},
-    {file = "coverage-7.2.7-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63426706118b7f5cf6bb6c895dc215d8a418d5952544042c8a2d9fe87fcf09cb"},
-    {file = "coverage-7.2.7-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:afb17f84d56068a7c29f5fa37bfd38d5aba69e3304af08ee94da8ed5b0865833"},
-    {file = "coverage-7.2.7-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:48c19d2159d433ccc99e729ceae7d5293fbffa0bdb94952d3579983d1c8c9d97"},
-    {file = "coverage-7.2.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e1f928eaf5469c11e886fe0885ad2bf1ec606434e79842a879277895a50942a"},
-    {file = "coverage-7.2.7-cp311-cp311-win32.whl", hash = "sha256:33d6d3ea29d5b3a1a632b3c4e4f4ecae24ef170b0b9ee493883f2df10039959a"},
-    {file = "coverage-7.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:5b7540161790b2f28143191f5f8ec02fb132660ff175b7747b95dcb77ac26562"},
-    {file = "coverage-7.2.7-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f2f67fe12b22cd130d34d0ef79206061bfb5eda52feb6ce0dba0644e20a03cf4"},
-    {file = "coverage-7.2.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a342242fe22407f3c17f4b499276a02b01e80f861f1682ad1d95b04018e0c0d4"},
-    {file = "coverage-7.2.7-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:171717c7cb6b453aebac9a2ef603699da237f341b38eebfee9be75d27dc38e01"},
-    {file = "coverage-7.2.7-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49969a9f7ffa086d973d91cec8d2e31080436ef0fb4a359cae927e742abfaaa6"},
-    {file = "coverage-7.2.7-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b46517c02ccd08092f4fa99f24c3b83d8f92f739b4657b0f146246a0ca6a831d"},
-    {file = "coverage-7.2.7-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:a3d33a6b3eae87ceaefa91ffdc130b5e8536182cd6dfdbfc1aa56b46ff8c86de"},
-    {file = "coverage-7.2.7-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:976b9c42fb2a43ebf304fa7d4a310e5f16cc99992f33eced91ef6f908bd8f33d"},
-    {file = "coverage-7.2.7-cp312-cp312-win32.whl", hash = "sha256:8de8bb0e5ad103888d65abef8bca41ab93721647590a3f740100cd65c3b00511"},
-    {file = "coverage-7.2.7-cp312-cp312-win_amd64.whl", hash = "sha256:9e31cb64d7de6b6f09702bb27c02d1904b3aebfca610c12772452c4e6c21a0d3"},
-    {file = "coverage-7.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58c2ccc2f00ecb51253cbe5d8d7122a34590fac9646a960d1430d5b15321d95f"},
-    {file = "coverage-7.2.7-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d22656368f0e6189e24722214ed8d66b8022db19d182927b9a248a2a8a2f67eb"},
-    {file = "coverage-7.2.7-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a895fcc7b15c3fc72beb43cdcbdf0ddb7d2ebc959edac9cef390b0d14f39f8a9"},
-    {file = "coverage-7.2.7-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e84606b74eb7de6ff581a7915e2dab7a28a0517fbe1c9239eb227e1354064dcd"},
-    {file = "coverage-7.2.7-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0a5f9e1dbd7fbe30196578ca36f3fba75376fb99888c395c5880b355e2875f8a"},
-    {file = "coverage-7.2.7-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:419bfd2caae268623dd469eff96d510a920c90928b60f2073d79f8fe2bbc5959"},
-    {file = "coverage-7.2.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2aee274c46590717f38ae5e4650988d1af340fe06167546cc32fe2f58ed05b02"},
-    {file = "coverage-7.2.7-cp37-cp37m-win32.whl", hash = "sha256:61b9a528fb348373c433e8966535074b802c7a5d7f23c4f421e6c6e2f1697a6f"},
-    {file = "coverage-7.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:b1c546aca0ca4d028901d825015dc8e4d56aac4b541877690eb76490f1dc8ed0"},
-    {file = "coverage-7.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:54b896376ab563bd38453cecb813c295cf347cf5906e8b41d340b0321a5433e5"},
-    {file = "coverage-7.2.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3d376df58cc111dc8e21e3b6e24606b5bb5dee6024f46a5abca99124b2229ef5"},
-    {file = "coverage-7.2.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e330fc79bd7207e46c7d7fd2bb4af2963f5f635703925543a70b99574b0fea9"},
-    {file = "coverage-7.2.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e9d683426464e4a252bf70c3498756055016f99ddaec3774bf368e76bbe02b6"},
-    {file = "coverage-7.2.7-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d13c64ee2d33eccf7437961b6ea7ad8673e2be040b4f7fd4fd4d4d28d9ccb1e"},
-    {file = "coverage-7.2.7-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b7aa5f8a41217360e600da646004f878250a0d6738bcdc11a0a39928d7dc2050"},
-    {file = "coverage-7.2.7-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8fa03bce9bfbeeef9f3b160a8bed39a221d82308b4152b27d82d8daa7041fee5"},
-    {file = "coverage-7.2.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:245167dd26180ab4c91d5e1496a30be4cd721a5cf2abf52974f965f10f11419f"},
-    {file = "coverage-7.2.7-cp38-cp38-win32.whl", hash = "sha256:d2c2db7fd82e9b72937969bceac4d6ca89660db0a0967614ce2481e81a0b771e"},
-    {file = "coverage-7.2.7-cp38-cp38-win_amd64.whl", hash = "sha256:2e07b54284e381531c87f785f613b833569c14ecacdcb85d56b25c4622c16c3c"},
-    {file = "coverage-7.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:537891ae8ce59ef63d0123f7ac9e2ae0fc8b72c7ccbe5296fec45fd68967b6c9"},
-    {file = "coverage-7.2.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:06fb182e69f33f6cd1d39a6c597294cff3143554b64b9825d1dc69d18cc2fff2"},
-    {file = "coverage-7.2.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:201e7389591af40950a6480bd9edfa8ed04346ff80002cec1a66cac4549c1ad7"},
-    {file = "coverage-7.2.7-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6951407391b639504e3b3be51b7ba5f3528adbf1a8ac3302b687ecababf929e"},
-    {file = "coverage-7.2.7-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f48351d66575f535669306aa7d6d6f71bc43372473b54a832222803eb956fd1"},
-    {file = "coverage-7.2.7-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b29019c76039dc3c0fd815c41392a044ce555d9bcdd38b0fb60fb4cd8e475ba9"},
-    {file = "coverage-7.2.7-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:81c13a1fc7468c40f13420732805a4c38a105d89848b7c10af65a90beff25250"},
-    {file = "coverage-7.2.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:975d70ab7e3c80a3fe86001d8751f6778905ec723f5b110aed1e450da9d4b7f2"},
-    {file = "coverage-7.2.7-cp39-cp39-win32.whl", hash = "sha256:7ee7d9d4822c8acc74a5e26c50604dff824710bc8de424904c0982e25c39c6cb"},
-    {file = "coverage-7.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:eb393e5ebc85245347950143969b241d08b52b88a3dc39479822e073a1a8eb27"},
-    {file = "coverage-7.2.7-pp37.pp38.pp39-none-any.whl", hash = "sha256:b7b4c971f05e6ae490fef852c218b0e79d4e52f79ef0c8475566584a8fb3e01d"},
-    {file = "coverage-7.2.7.tar.gz", hash = "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59"},
+    {file = "coverage-7.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db76a1bcb51f02b2007adacbed4c88b6dee75342c37b05d1822815eed19edee5"},
+    {file = "coverage-7.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c02cfa6c36144ab334d556989406837336c1d05215a9bdf44c0bc1d1ac1cb637"},
+    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:477c9430ad5d1b80b07f3c12f7120eef40bfbf849e9e7859e53b9c93b922d2af"},
+    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce2ee86ca75f9f96072295c5ebb4ef2a43cecf2870b0ca5e7a1cbdd929cf67e1"},
+    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68d8a0426b49c053013e631c0cdc09b952d857efa8f68121746b339912d27a12"},
+    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b3eb0c93e2ea6445b2173da48cb548364f8f65bf68f3d090404080d338e3a689"},
+    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:90b6e2f0f66750c5a1178ffa9370dec6c508a8ca5265c42fbad3ccac210a7977"},
+    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:96d7d761aea65b291a98c84e1250cd57b5b51726821a6f2f8df65db89363be51"},
+    {file = "coverage-7.3.0-cp310-cp310-win32.whl", hash = "sha256:63c5b8ecbc3b3d5eb3a9d873dec60afc0cd5ff9d9f1c75981d8c31cfe4df8527"},
+    {file = "coverage-7.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:97c44f4ee13bce914272589b6b41165bbb650e48fdb7bd5493a38bde8de730a1"},
+    {file = "coverage-7.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74c160285f2dfe0acf0f72d425f3e970b21b6de04157fc65adc9fd07ee44177f"},
+    {file = "coverage-7.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b543302a3707245d454fc49b8ecd2c2d5982b50eb63f3535244fd79a4be0c99d"},
+    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad0f87826c4ebd3ef484502e79b39614e9c03a5d1510cfb623f4a4a051edc6fd"},
+    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13c6cbbd5f31211d8fdb477f0f7b03438591bdd077054076eec362cf2207b4a7"},
+    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fac440c43e9b479d1241fe9d768645e7ccec3fb65dc3a5f6e90675e75c3f3e3a"},
+    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3c9834d5e3df9d2aba0275c9f67989c590e05732439b3318fa37a725dff51e74"},
+    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4c8e31cf29b60859876474034a83f59a14381af50cbe8a9dbaadbf70adc4b214"},
+    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7a9baf8e230f9621f8e1d00c580394a0aa328fdac0df2b3f8384387c44083c0f"},
+    {file = "coverage-7.3.0-cp311-cp311-win32.whl", hash = "sha256:ccc51713b5581e12f93ccb9c5e39e8b5d4b16776d584c0f5e9e4e63381356482"},
+    {file = "coverage-7.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:887665f00ea4e488501ba755a0e3c2cfd6278e846ada3185f42d391ef95e7e70"},
+    {file = "coverage-7.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d000a739f9feed900381605a12a61f7aaced6beae832719ae0d15058a1e81c1b"},
+    {file = "coverage-7.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59777652e245bb1e300e620ce2bef0d341945842e4eb888c23a7f1d9e143c446"},
+    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9737bc49a9255d78da085fa04f628a310c2332b187cd49b958b0e494c125071"},
+    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5247bab12f84a1d608213b96b8af0cbb30d090d705b6663ad794c2f2a5e5b9fe"},
+    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ac9a1de294773b9fa77447ab7e529cf4fe3910f6a0832816e5f3d538cfea9a"},
+    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:85b7335c22455ec12444cec0d600533a238d6439d8d709d545158c1208483873"},
+    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:36ce5d43a072a036f287029a55b5c6a0e9bd73db58961a273b6dc11a2c6eb9c2"},
+    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:211a4576e984f96d9fce61766ffaed0115d5dab1419e4f63d6992b480c2bd60b"},
+    {file = "coverage-7.3.0-cp312-cp312-win32.whl", hash = "sha256:56afbf41fa4a7b27f6635bc4289050ac3ab7951b8a821bca46f5b024500e6321"},
+    {file = "coverage-7.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f297e0c1ae55300ff688568b04ff26b01c13dfbf4c9d2b7d0cb688ac60df479"},
+    {file = "coverage-7.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac0dec90e7de0087d3d95fa0533e1d2d722dcc008bc7b60e1143402a04c117c1"},
+    {file = "coverage-7.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:438856d3f8f1e27f8e79b5410ae56650732a0dcfa94e756df88c7e2d24851fcd"},
+    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1084393c6bda8875c05e04fce5cfe1301a425f758eb012f010eab586f1f3905e"},
+    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49ab200acf891e3dde19e5aa4b0f35d12d8b4bd805dc0be8792270c71bd56c54"},
+    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67e6bbe756ed458646e1ef2b0778591ed4d1fcd4b146fc3ba2feb1a7afd4254"},
+    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8f39c49faf5344af36042b293ce05c0d9004270d811c7080610b3e713251c9b0"},
+    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7df91fb24c2edaabec4e0eee512ff3bc6ec20eb8dccac2e77001c1fe516c0c84"},
+    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:34f9f0763d5fa3035a315b69b428fe9c34d4fc2f615262d6be3d3bf3882fb985"},
+    {file = "coverage-7.3.0-cp38-cp38-win32.whl", hash = "sha256:bac329371d4c0d456e8d5f38a9b0816b446581b5f278474e416ea0c68c47dcd9"},
+    {file = "coverage-7.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b859128a093f135b556b4765658d5d2e758e1fae3e7cc2f8c10f26fe7005e543"},
+    {file = "coverage-7.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed8d310afe013db1eedd37176d0839dc66c96bcfcce8f6607a73ffea2d6ba"},
+    {file = "coverage-7.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61260ec93f99f2c2d93d264b564ba912bec502f679793c56f678ba5251f0393"},
+    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97af9554a799bd7c58c0179cc8dbf14aa7ab50e1fd5fa73f90b9b7215874ba28"},
+    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3558e5b574d62f9c46b76120a5c7c16c4612dc2644c3d48a9f4064a705eaee95"},
+    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37d5576d35fcb765fca05654f66aa71e2808d4237d026e64ac8b397ffa66a56a"},
+    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:07ea61bcb179f8f05ffd804d2732b09d23a1238642bf7e51dad62082b5019b34"},
+    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:80501d1b2270d7e8daf1b64b895745c3e234289e00d5f0e30923e706f110334e"},
+    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4eddd3153d02204f22aef0825409091a91bf2a20bce06fe0f638f5c19a85de54"},
+    {file = "coverage-7.3.0-cp39-cp39-win32.whl", hash = "sha256:2d22172f938455c156e9af2612650f26cceea47dc86ca048fa4e0b2d21646ad3"},
+    {file = "coverage-7.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:60f64e2007c9144375dd0f480a54d6070f00bb1a28f65c408370544091c9bc9e"},
+    {file = "coverage-7.3.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:5492a6ce3bdb15c6ad66cb68a0244854d9917478877a25671d70378bdc8562d0"},
+    {file = "coverage-7.3.0.tar.gz", hash = "sha256:49dbb19cdcafc130f597d9e04a29d0a032ceedf729e41b181f51cd170e6ee865"},
 ]
 
 [package.dependencies]
@@ -597,14 +589,14 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
-    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 
 [package.extras]
@@ -2143,14 +2135,14 @@ test = ["coverage", "mypy", "ruff", "wheel"]
 
 [[package]]
 name = "pypdf"
-version = "3.15.0"
+version = "3.15.1"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pypdf-3.15.0-py3-none-any.whl", hash = "sha256:2e29ddb62561ec91157c784783714703ddd3ce08f070ecbc57404fb86cd9fc97"},
-    {file = "pypdf-3.15.0.tar.gz", hash = "sha256:8a6264e1c47c63dc2484e29bdfa76b121435896a84e94b7c5ae82c6ae96354bb"},
+    {file = "pypdf-3.15.1-py3-none-any.whl", hash = "sha256:99b337af7da8046d1e2e94354846e8c56753e1cdc817ac0fbe770c1e2281902b"},
+    {file = "pypdf-3.15.1.tar.gz", hash = "sha256:d0dfaf4f10dfb06ac39e1d6a9cbffd63e77621d1e89c0ef08f346fd902df7b4b"},
 ]
 
 [package.dependencies]
@@ -2957,19 +2949,19 @@ urllib3 = {version = ">=1.26,<3", extras = ["socks"]}
 
 [[package]]
 name = "setuptools"
-version = "68.0.0"
+version = "68.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
-    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+    {file = "setuptools-68.1.0-py3-none-any.whl", hash = "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"},
+    {file = "setuptools-68.1.0.tar.gz", hash = "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -3291,14 +3283,14 @@ files = [
 
 [[package]]
 name = "tenacity"
-version = "8.2.2"
+version = "8.2.3"
 description = "Retry code until it succeeds"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "tenacity-8.2.2-py3-none-any.whl", hash = "sha256:2f277afb21b851637e8f52e6a613ff08734c347dc19ade928e519d7d2d8569b0"},
-    {file = "tenacity-8.2.2.tar.gz", hash = "sha256:43af037822bd0029025877f3b2d97cc4d7bb0c2991000a3d59d71517c5c969e0"},
+    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
+    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
 ]
 
 [package.extras]

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -1468,34 +1468,39 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.5.0"
+version = "1.5.1"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ad3109bec37cc33654de8db30fe8ff3a1bb57ea65144167d68185e6dced9868d"},
-    {file = "mypy-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b4ea3a0241cb005b0ccdbd318fb99619b21ae51bcf1660b95fc22e0e7d3ba4a1"},
-    {file = "mypy-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fe816e26e676c1311b9e04fd576543b873576d39439f7c24c8e5c7728391ecf"},
-    {file = "mypy-1.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:42170e68adb1603ccdc55a30068f72bcfcde2ce650188e4c1b2a93018b826735"},
-    {file = "mypy-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:d145b81a8214687cfc1f85c03663a5bbe736777410e5580e54d526e7e904f564"},
-    {file = "mypy-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c36011320e452eb30bec38b9fd3ba20569dc9545d7d4540d967f3ea1fab9c374"},
-    {file = "mypy-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f3940cf5845b2512b3ab95463198b0cdf87975dfd17fdcc6ce9709a9abe09e69"},
-    {file = "mypy-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9166186c498170e1ff478a7f540846b2169243feb95bc228d39a67a1a450cdc6"},
-    {file = "mypy-1.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:725b57a19b7408ef66a0fd9db59b5d3e528922250fb56e50bded27fea9ff28f0"},
-    {file = "mypy-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:eec5c927aa4b3e8b4781840f1550079969926d0a22ce38075f6cfcf4b13e3eb4"},
-    {file = "mypy-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79c520aa24f21852206b5ff2cf746dc13020113aa73fa55af504635a96e62718"},
-    {file = "mypy-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:769ddb6bfe55c2bd9c7d6d7020885a5ea14289619db7ee650e06b1ef0852c6f4"},
-    {file = "mypy-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbf18f8db7e5f060d61c91e334d3b96d6bb624ddc9ee8a1cde407b737acbca2c"},
-    {file = "mypy-1.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a2500ad063413bc873ae102cf655bf49889e0763b260a3a7cf544a0cbbf7e70a"},
-    {file = "mypy-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:84cf9f7d8a8a22bb6a36444480f4cbf089c917a4179fbf7eea003ea931944a7f"},
-    {file = "mypy-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a551ed0fc02455fe2c1fb0145160df8336b90ab80224739627b15ebe2b45e9dc"},
-    {file = "mypy-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:372fd97293ed0076d52695849f59acbbb8461c4ab447858cdaeaf734a396d823"},
-    {file = "mypy-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8a7444d6fcac7e2585b10abb91ad900a576da7af8f5cffffbff6065d9115813"},
-    {file = "mypy-1.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:35b13335c6c46a386577a51f3d38b2b5d14aa619e9633bb756bd77205e4bd09f"},
-    {file = "mypy-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:2c9d570f53908cbea326ad8f96028a673b814d9dca7515bf71d95fa662c3eb6f"},
-    {file = "mypy-1.5.0-py3-none-any.whl", hash = "sha256:69b32d0dedd211b80f1b7435644e1ef83033a2af2ac65adcdc87c38db68a86be"},
-    {file = "mypy-1.5.0.tar.gz", hash = "sha256:f3460f34b3839b9bc84ee3ed65076eb827cd99ed13ed08d723f9083cada4a212"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
+    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
+    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
+    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
+    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
+    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
+    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
+    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
+    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
+    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
+    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
+    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
+    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
+    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
+    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
+    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
+    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
+    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
 ]
 
 [package.dependencies]

--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -348,14 +348,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.6"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
-    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "25.0.1"
+version = "26.0.0"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/main/src/RPA/Excel/Application.py
+++ b/packages/main/src/RPA/Excel/Application.py
@@ -81,14 +81,11 @@ class Application(BaseApplication):
         self.workbook = None
         self.worksheet = None
 
-    @functools.wraps(BaseApplication.close_document)
-    def close_document(self, *args, **kwargs):
-        if not self.workbook:
-            return
+    @property
+    def _active_document(self):
+        return self.workbook
 
-        self.app.ActiveDocument = self.workbook
-        super().close_document(*args, **kwargs)
-
+    def _deactivate_document(self):
         self.workbook = None
         self.worksheet = None
 

--- a/packages/main/src/RPA/Excel/Application.py
+++ b/packages/main/src/RPA/Excel/Application.py
@@ -109,7 +109,7 @@ class Application(BaseApplication):
 
         path = to_path(filename)
         if not path.is_file():
-            raise FileNotFoundError(f"{path} doesn't exist")
+            raise FileNotFoundError(f"{str(path)!r} doesn't exist")
         path = str(path)
         self.logger.info("Opening workbook: %s", path)
 

--- a/packages/main/src/RPA/Excel/Application.py
+++ b/packages/main/src/RPA/Excel/Application.py
@@ -18,16 +18,7 @@ def requires_workbook(func):
 
 
 class Application(BaseApplication):
-    """`Excel.Application` is a library for controlling an Excel application.
-
-    The library will automatically close the Excel application at the end of the
-    task execution. This can be changed by importing library with the
-    `autoexit=${False}` setting.
-
-    .. code-block:: robotframework
-
-        *** Settings ***
-        Library                 RPA.Excel.Application   autoexit=${False}
+    """`Excel.Application` is a library for controlling the Excel application.
 
     **Examples**
 
@@ -136,25 +127,15 @@ class Application(BaseApplication):
             elif sheetname:
                 self.worksheet = self.workbook.Worksheets(sheetname)
 
-    def add_new_sheet(
-        self, sheetname: str, tabname: str = None, create_workbook: bool = True
-    ) -> None:
+    def add_new_sheet(self, sheetname: str, create_workbook: bool = True) -> None:
         """Add new worksheet to workbook. Workbook is created by default if
         it does not exist.
 
         :param sheetname: name for sheet
-        :param tabname: name for tab (deprecated)
         :param create_workbook: create workbook if True, defaults to True
         :raises ValueError: error is raised if workbook does not exist and
             `create_workbook` is False
         """
-        if tabname:
-            sheetname = tabname
-            self.logger.warning(
-                "Argument 'tabname' is deprecated, "
-                "and will be removed in a future version"
-            )
-
         if not self.workbook:
             if not create_workbook:
                 raise ValueError("No workbook open")
@@ -177,8 +158,6 @@ class Application(BaseApplication):
         :return: row or None
         """
         cell = self.find_first_available_cell(worksheet, row, column)
-        # Note: keep return type for backward compability for now
-        # return cell[0] if cell else None
         return cell
 
     @requires_workbook

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -11,20 +11,19 @@ class Application(BaseApplication):
     # pylint: disable=C0301
     """`Outlook.Application` is a library for controlling the Outlook application.
 
-    *Note*. Library works only Windows platform.
-
-    Library will automatically close the Outlook application at the end of the
-    task execution. This can be changed by importing library with `autoexit` setting.
+    The library will automatically close the Outlook application at the end of the
+    task execution. This can be changed by importing library with the
+    `autoexit=${False}` setting.
 
     .. code-block:: robotframework
 
         *** Settings ***
-        Library                 RPA.Outlook.Application   autoexit=${FALSE}
+        Library                 RPA.Outlook.Application   autoexit=${False}
 
     **About Email Filtering**
 
-    Emails can be filtered according to specification set by Restrict method of the Item
-    class https://docs.microsoft.com/en-us/office/vba/api/outlook.items.restrict.
+    Emails can be filtered according to specification set by Restrict method of the
+    Item class https://docs.microsoft.com/en-us/office/vba/api/outlook.items.restrict.
 
     Couple of examples:
 

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -11,15 +11,6 @@ class Application(BaseApplication):
     # pylint: disable=C0301
     """`Outlook.Application` is a library for controlling the Outlook application.
 
-    The library will automatically close the Outlook application at the end of the
-    task execution. This can be changed by importing library with the
-    `autoexit=${False}` setting.
-
-    .. code-block:: robotframework
-
-        *** Settings ***
-        Library                 RPA.Outlook.Application   autoexit=${False}
-
     **About Email Filtering**
 
     Emails can be filtered according to specification set by Restrict method of the
@@ -75,44 +66,6 @@ class Application(BaseApplication):
     """  # noqa: E501
 
     APP_DISPATCH = "Outlook.Application"
-
-    def send_message(
-        self,
-        recipients: Union[str, List[str]],
-        subject: str,
-        body: str,
-        html_body: bool = False,
-        attachments: Optional[Union[str, List[str]]] = None,
-        save_as_draft: bool = False,
-        cc_recipients: Optional[Union[str, List[str]]] = None,
-        bcc_recipients: Optional[Union[str, List[str]]] = None,
-    ) -> bool:
-        """Send message with Outlook
-
-        :param recipients: list of addresses
-        :param subject: email subject
-        :param body: email body
-        :param html_body: True if body contains HTML, defaults to False
-        :param attachments: list of filepaths to include in the email, defaults to []
-        :param save_as_draft: message is saved as draft when `True`
-         instead (and not sent)
-        :return: `True` if there were no errors
-        """
-        self.logger.warning(
-            "Keyword 'Send Message' is deprecated, "
-            "and will be removed in a future version."
-            "Use 'Send Email' instead."
-        )
-        return self.send_email(
-            recipients,
-            subject,
-            body,
-            html_body,
-            attachments,
-            save_as_draft,
-            cc_recipients,
-            bcc_recipients,
-        )
 
     def send_email(
         self,
@@ -236,31 +189,6 @@ class Application(BaseApplication):
             match_found = email
 
         return match_found
-
-    def wait_for_message(
-        self, criterion: str = None, timeout: float = 5.0, interval: float = 1.0
-    ) -> Any:
-        """Wait for email matching `criterion` to arrive into mailbox.
-
-        :param criterion: message filter to wait for, defaults to ""
-        :param timeout: total time in seconds to wait for email, defaults to 5.0
-        :param interval: time in seconds for new check, defaults to 1.0
-        :return: list of messages or False
-
-        Possible wait criterias are: SUBJECT, SENDER and BODY
-
-        Example:
-
-        .. code-block:: robotframework
-
-            Wait for message     SUBJECT:rpa task calling    timeout=300    interval=10
-        """
-        self.logger.warning(
-            "Keyword 'Wait For Message' is deprecated, "
-            "and will be removed in a future version."
-            "Use 'Wait For Email' instead."
-        )
-        return self.wait_for_email(criterion, timeout, interval)
 
     def wait_for_email(
         self, criterion: str = None, timeout: float = 5.0, interval: float = 1.0

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -1,10 +1,10 @@
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Union, Optional
+from typing import Any, List, Optional, Union
 
-from RPA.Email.common import counter_duplicate_path
 from RPA.application import BaseApplication, COMError
+from RPA.Email.common import counter_duplicate_path
 
 
 class Application(BaseApplication):
@@ -188,9 +188,10 @@ class Application(BaseApplication):
             else:
                 mail.Send()
                 self.logger.debug("Email sent")
-        except COMError as e:
+        # On non-Windows OS `COMError` is `Exception`.
+        except COMError as exc:  # pylint: disable=broad-except
             self.logger.error(
-                f"Mail {'saving' if save_as_draft else 'sending'} failed: %s", e
+                f"Mail {'saving' if save_as_draft else 'sending'} failed: %s", exc
             )
             return False
         return True
@@ -280,8 +281,6 @@ class Application(BaseApplication):
 
             Wait for Email     SUBJECT:rpa task calling    timeout=300    interval=10
         """
-        if self.app is None:
-            raise ValueError("Requires active Outlook Application")
         if criterion is None:
             self.logger.warning(
                 "Wait for message requires criteria for which message to wait for."
@@ -351,7 +350,7 @@ class Application(BaseApplication):
         if folder_messages and email_filter:
             try:
                 folder_messages = folder_messages.Restrict(email_filter)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 raise AttributeError(  # pylint: disable=raise-missing-from
                     "Invalid email filter '%s'" % email_filter
                 )
@@ -359,7 +358,7 @@ class Application(BaseApplication):
             sort_key = sort_key or "ReceivedTime"
             try:
                 folder_messages.Sort(f"[{sort_key}]", sort_descending)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 raise AttributeError(  # pylint: disable=raise-missing-from
                     "Invalid email sort key '%s'" % sort_key
                 )
@@ -396,7 +395,6 @@ class Application(BaseApplication):
         return account_folder
 
     def _get_matching_folder(self, folder_name, folder=None):
-        folders = []
         if not folder or isinstance(folder, str):
             folders = self.app.GetNamespace("MAPI").Folders
         elif isinstance(folder, list):
@@ -525,7 +523,7 @@ class Application(BaseApplication):
         if folder_messages and email_filter:
             try:
                 folder_messages = folder_messages.Restrict(email_filter)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 raise AttributeError(  # pylint: disable=raise-missing-from
                     "Invalid email filter '%s'" % email_filter
                 )

--- a/packages/main/src/RPA/Word/Application.py
+++ b/packages/main/src/RPA/Word/Application.py
@@ -8,17 +8,7 @@ from RPA.application import (
 
 
 class Application(BaseApplication):
-    """`Word.Application` is a library for controlling a Word application.
-
-    *Note*. Library works only Windows platform.
-
-    Library will automatically close the Word application at the end of the
-    task execution. This can be changed by importing library with `autoexit` setting.
-
-    .. code-block:: robotframework
-
-        *** Settings ***
-        Library                 RPA.Word.Application   autoexit=${FALSE}
+    """`Word.Application` is a library for controlling the Word application.
 
     **Examples**
 

--- a/packages/main/src/RPA/Word/Application.py
+++ b/packages/main/src/RPA/Word/Application.py
@@ -1,28 +1,13 @@
-import atexit
-import logging
-from pathlib import Path
-import platform
-
-if platform.system() == "Windows":
-    import win32com.client
-    from win32com.client import constants
-else:
-    logging.getLogger(__name__).warning(
-        "RPA.Word.Application library works only on Windows platform"
-    )
+from RPA.application import (
+    BaseApplication,
+    catch_com_error,
+    constants,
+    to_path,
+    to_str_path,
+)
 
 
-FILEFORMATS = {
-    "DEFAULT": "wdFormatDocumentDefault",
-    "PDF": "wdFormatPDF",
-    "RTF": "wdFormatRTF",
-    "HTML": "wdFormatHTML",
-    "WORD97": "wdFormatDocument97",
-    "OPENDOCUMENT": "wdFormatOpenDocumentText",
-}
-
-
-class Application:
+class Application(BaseApplication):
     """`Word.Application` is a library for controlling a Word application.
 
     *Note*. Library works only Windows platform.
@@ -69,73 +54,60 @@ class Application:
         app.quit_application()
     """
 
-    ROBOT_LIBRARY_SCOPE = "GLOBAL"
-    ROBOT_LIBRARY_DOC_FORMAT = "REST"
+    APP_DISPATCH = "Word.Application"
+    FILEFORMATS = {
+        "DEFAULT": "wdFormatDocumentDefault",
+        "PDF": "wdFormatPDF",
+        "RTF": "wdFormatRTF",
+        "HTML": "wdFormatHTML",
+        "WORD97": "wdFormatDocument97",
+        "OPENDOCUMENT": "wdFormatOpenDocumentText",
+    }
 
-    def __init__(self, autoexit: bool = True) -> None:
-        self.logger = logging.getLogger(__name__)
-        self.app = None
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.filename = None
-
-        if platform.system() != "Windows":
-            self.logger.warning(
-                "Word application library requires Windows dependencies to work."
-            )
-
-        if autoexit:
-            atexit.register(self.quit_application)
-
-    def open_application(
-        self, visible: bool = False, display_alerts: bool = False
-    ) -> None:
-        """Open the Word application.
-
-        :param visible: show window after opening
-        :param display_alerts: show alert popups
-        """
-        self.app = win32com.client.gencache.EnsureDispatch("Word.Application")
-
-        if hasattr(self.app, "Visible"):
-            self.app.Visible = visible
-
-        # show eg. file overwrite warning or not
-        if hasattr(self.app, "DisplayAlerts"):
-            self.app.DisplayAlerts = display_alerts
-
-    def close_document(self, save_changes: bool = False) -> None:
-        """Close the active document (if open)."""
-        if self.app is not None:
-            self.app.ActiveDocument.Close(save_changes)
-
-    def quit_application(self, save_changes: bool = False) -> None:
-        """Quit the application."""
-        if self.app is not None:
-            self.close_document(save_changes)
-            self.app.Quit()
-            self.app = None
 
     def open_file(self, filename: str, read_only: bool = True) -> None:
         """Open Word document with filename.
 
         :param filename: Word document path
         """
-        path = str(Path(filename).resolve())
-        self.logger.info("Opening document: %s", path)
+        path = to_path(filename)
+        if not path.is_file():
+            raise FileNotFoundError(f"{path} doesn't exist")
 
-        doc = self.app.Documents.Open(
-            FileName=path,
-            ConfirmConversions=False,
-            ReadOnly=read_only,
-            AddToRecentFiles=False,
-        )
+        state = "read-only" if read_only else "read-write"
+        self.logger.info("Opening document (%s): %s", state, path)
+        with catch_com_error():
+            doc = self.app.Documents.Open(
+                FileName=str(path),
+                ConfirmConversions=False,
+                ReadOnly=read_only,
+                AddToRecentFiles=False,
+            )
+
+        err_msg = None
+        if doc is None:
+            err_msg = (
+                "Got null object when opening the document, enable RDP connection if"
+                " running by Control Room through a Worker service"
+            )
+        elif not hasattr(doc, "Activate"):
+            err_msg = (
+                "The document can't be activated, open it manually and dismiss any"
+                " alert you may encounter first"
+            )
+        if err_msg:
+            raise IOError(err_msg)
 
         doc.Activate()
         self.app.ActiveWindow.View.ReadingLayout = False
-        self.filename = path
 
     def create_new_document(self) -> None:
         """Create new document for Word application"""
-        if self.app:
+        with catch_com_error():
             self.app.Documents.Add()
 
     def export_to_pdf(self, filename: str) -> None:
@@ -143,10 +115,11 @@ class Application:
 
         :param filename: PDF to export WORD into
         """
-        path = str(Path(filename).resolve())
-        self.app.ActiveDocument.ExportAsFixedFormat(
-            OutputFileName=path, ExportFormat=constants.wdExportFormatPDF
-        )
+        path = to_str_path(filename)
+        with catch_com_error():
+            self.app.ActiveDocument.ExportAsFixedFormat(
+                OutputFileName=path, ExportFormat=constants.wdExportFormatPDF
+            )
 
     def write_text(self, text: str, newline: bool = True) -> None:
         """Writes given text at the end of the document
@@ -158,7 +131,6 @@ class Application:
         if newline:
             text = f"\n{text}"
         self.app.Selection.TypeText(text)
-        # self.app.ActiveDocument.Content.InsertAfter(text)
 
     def replace_text(self, find: str, replace: str) -> None:
         """Replace text in active document
@@ -203,7 +175,7 @@ class Application:
         :param fileformat: see @FILEFORMATS dictionary for possible format,
             defaults to None
         """
-        path = str(Path(filename).resolve())
+        path = to_str_path(filename)
 
         # Accept all revisions
         self.app.ActiveDocument.Revisions.AcceptAll()
@@ -211,9 +183,9 @@ class Application:
         if self.app.ActiveDocument.Comments.Count >= 1:
             self.app.ActiveDocument.DeleteAllComments()
 
-        if fileformat and fileformat.upper() in FILEFORMATS.keys():
+        if fileformat and fileformat.upper() in self.FILEFORMATS:
             self.logger.debug("Saving with file format: %s", fileformat)
-            format_name = FILEFORMATS[fileformat.upper()]
+            format_name = self.FILEFORMATS[fileformat.upper()]
             format_type = getattr(constants, format_name)
         else:
             format_type = constants.wdFormatDocumentDefault

--- a/packages/main/src/RPA/Word/Application.py
+++ b/packages/main/src/RPA/Word/Application.py
@@ -117,7 +117,7 @@ class Application(BaseApplication):
         """
         path = to_str_path(filename)
         with catch_com_error():
-            self.app.ActiveDocument.ExportAsFixedFormat(
+            self._active_document.ExportAsFixedFormat(
                 OutputFileName=path, ExportFormat=constants.wdExportFormatPDF
             )
 
@@ -138,14 +138,14 @@ class Application(BaseApplication):
         :param find: text to replace
         :param replace: new text
         """
-        self.app.ActiveDocument.Content.Find.Execute(FindText=find, ReplaceWith=replace)
+        self._active_document.Content.Find.Execute(FindText=find, ReplaceWith=replace)
 
     def set_header(self, text: str) -> None:
         """Set header for the active document
 
         :param text: header text to set
         """
-        for section in self.app.ActiveDocument.Sections:
+        for section in self._active_document.Sections:
             for header in section.Headers:
                 header.Range.Text = text
 
@@ -154,19 +154,19 @@ class Application(BaseApplication):
 
         :param text: footer text to set
         """
-        for section in self.app.ActiveDocument.Sections:
+        for section in self._active_document.Sections:
             for footer in section.Footers:
                 footer.Range.Text = text
 
     def save_document(self) -> None:
         """Save active document"""
         # Accept all revisions
-        self.app.ActiveDocument.Revisions.AcceptAll()
+        self._active_document.Revisions.AcceptAll()
         # Delete all comments
-        if self.app.ActiveDocument.Comments.Count >= 1:
-            self.app.ActiveDocument.DeleteAllComments()
+        if self._active_document.Comments.Count >= 1:
+            self._active_document.DeleteAllComments()
 
-        self.app.ActiveDocument.Save()
+        self._active_document.Save()
 
     def save_document_as(self, filename: str, fileformat: str = None) -> None:
         """Save document with filename and optionally with given fileformat
@@ -178,10 +178,10 @@ class Application(BaseApplication):
         path = to_str_path(filename)
 
         # Accept all revisions
-        self.app.ActiveDocument.Revisions.AcceptAll()
+        self._active_document.Revisions.AcceptAll()
         # Delete all comments
-        if self.app.ActiveDocument.Comments.Count >= 1:
-            self.app.ActiveDocument.DeleteAllComments()
+        if self._active_document.Comments.Count >= 1:
+            self._active_document.DeleteAllComments()
 
         if fileformat and fileformat.upper() in self.FILEFORMATS:
             self.logger.debug("Saving with file format: %s", fileformat)
@@ -191,9 +191,9 @@ class Application(BaseApplication):
             format_type = constants.wdFormatDocumentDefault
 
         try:
-            self.app.ActiveDocument.SaveAs2(path, FileFormat=format_type)
+            self._active_document.SaveAs2(path, FileFormat=format_type)
         except AttributeError:
-            self.app.ActiveDocument.SaveAs(path, FileFormat=format_type)
+            self._active_document.SaveAs(path, FileFormat=format_type)
 
         self.logger.info("File saved to: %s", path)
 
@@ -202,4 +202,4 @@ class Application(BaseApplication):
 
         :return: texts
         """
-        return self.app.ActiveDocument.Content.Text
+        return self._active_document.Content.Text

--- a/packages/main/src/RPA/Word/Application.py
+++ b/packages/main/src/RPA/Word/Application.py
@@ -76,7 +76,7 @@ class Application(BaseApplication):
         """
         path = to_path(filename)
         if not path.is_file():
-            raise FileNotFoundError(f"{path} doesn't exist")
+            raise FileNotFoundError(f"{str(path)!r} doesn't exist")
 
         state = "read-only" if read_only else "read-write"
         self.logger.info("Opening document (%s): %s", state, path)

--- a/packages/main/src/RPA/Word/Application.py
+++ b/packages/main/src/RPA/Word/Application.py
@@ -54,11 +54,6 @@ class Application(BaseApplication):
         "OPENDOCUMENT": "wdFormatOpenDocumentText",
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.filename = None
-
     def open_file(self, filename: str, read_only: bool = True) -> None:
         """Open Word document with filename.
 

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -81,7 +81,11 @@ class BaseApplication(metaclass=MetaApplication):
 
     This library works on a Windows operating system with UI enabled only, and you must
     ensure that you open the app first with ``Open Application`` before running any
-    other relevant keyword which requires to operate on an open app.
+    other relevant keyword which requires to operate on an open app. Check the
+    documentation below for more info:
+
+    - https://robocorp.com/docs/control-room/unattended/worker-setups/windows-desktop
+    - https://robocorp.com/docs/faq/windows-server-2016
 
     If you're running the Process by Control Room through a custom self-hosted Worker
     service, then please make sure that you enable an RDP session by ticking "Use

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -163,8 +163,9 @@ class BaseApplication(metaclass=MetaApplication):
 
     @property
     def _active_document(self):
-        # Retrieves the currently active document. (raises COMError if there's none)
-        return getattr(self.app, "ActiveDocument", None)
+        # Retrieves the currently active document. (raises if there's none active)
+        with catch_com_error():
+            return getattr(self.app, "ActiveDocument", None)
 
     def _deactivate_document(self):
         # Cleans-up a just closed previously active document.

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -10,7 +10,7 @@ from pathlib import Path
 if platform.system() == "Windows":
     import win32api
     import win32com.client
-    from pywintypes import com_error as COMError
+    from pywintypes import com_error as COMError  # pylint: disable=no-name-in-module
     from win32com.client import constants  # pylint: disable=unused-import
 else:
     logging.getLogger(__name__).warning(

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -97,6 +97,10 @@ class BaseApplication(metaclass=MetaApplication):
     APP_DISPATCH = None  # this has to be defined in every inheriting class
 
     def __init__(self, autoexit: bool = True):
+        """Initialize the library instance by wrapping the COM Windows app.
+
+        :param autoexit: Automatically close the app when the process finishes.
+        """
         self.logger = logging.getLogger(__name__)
         self._app_name = self.APP_DISPATCH.split(".")[0]
         self._app = None
@@ -142,7 +146,7 @@ class BaseApplication(metaclass=MetaApplication):
     def close_document(self, save_changes: bool = False) -> None:
         """Close the active document and app (if open).
 
-        :param save_changes: Enable to save changes on quit. (defaults to `False`)
+        :param save_changes: Enable changes saving on quit. (`False` by default)
         """
         if not self._app:  # no app open at all
             return
@@ -156,7 +160,7 @@ class BaseApplication(metaclass=MetaApplication):
     def quit_application(self, save_changes: bool = False) -> None:
         """Quit the application.
 
-        :param save_changes: Enable to save changes on quit. (defaults to False)
+        :param save_changes: Enable to save changes on quit. (`False` by default)
         """
         if not self._app:
             return

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -1,0 +1,110 @@
+"""Base utilities for COM applications like Word, Excel, Outlook."""
+
+import atexit
+import logging
+import platform
+import struct
+from contextlib import contextmanager
+
+if platform.system() == "Windows":
+    import win32api
+    import win32com.client
+    from pywintypes import com_error as COMError
+else:
+    logging.getLogger(__name__).warning(
+        "Any `RPA.*.Application` library works only on Windows platform"
+    )
+    COMError = Exception
+
+
+def _to_unsigned(val):
+    return struct.unpack("L", struct.pack("l", val))[0]
+
+
+@contextmanager
+def catch_com_error():
+    """Try to convert COM errors to human-readable format."""
+    try:
+        yield
+    except COMError as err:  # pylint: disable=no-member
+        if err.excepinfo:
+            try:
+                msg = win32api.FormatMessage(_to_unsigned(err.excepinfo[5]))
+            except Exception:  # pylint: disable=broad-except
+                msg = err.excepinfo[2]
+        else:
+            try:
+                msg = win32api.FormatMessage(_to_unsigned(err.hresult))
+            except Exception:  # pylint: disable=broad-except
+                msg = err.strerror
+        raise RuntimeError(msg) from err
+
+
+class BaseApplication:
+    """Base library `Application` class for managing COM apps."""
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+    ROBOT_LIBRARY_DOC_FORMAT = "REST"
+
+    APP_DISPATCH = None  # this has to be defined in every inheriting class
+
+    def __init__(self, autoexit: bool = True):
+        self.logger = logging.getLogger(__name__)
+        self.app = None
+
+        if platform.system() != "Windows":
+            self.logger.warning(
+                "This Application library requires Windows dependencies to work."
+            )
+        if autoexit:
+            atexit.register(self.quit_application)
+
+    def open_application(
+        self, visible: bool = False, display_alerts: bool = False
+    ) -> None:
+        """Open the application.
+
+        :param visible: Show the window on opening. (`False` by default)
+        :param display_alerts: Display alert popups. (`False` by default)
+        """
+        with catch_com_error():
+            self.app = win32com.client.gencache.EnsureDispatch(self.APP_DISPATCH)
+            self.logger.debug("Opened application: %s", self.app)
+
+            if hasattr(self.app, "Visible"):
+                state = "visible" if visible else "invisible"
+                self.logger.debug("Making the application %s.", state)
+                self.app.Visible = visible
+
+            # Show for e.g. a file overwrite warning or not.
+            if hasattr(self.app, "DisplayAlerts"):
+                state = "Displaying" is display_alerts else "Hiding"
+                self.logger.debug("%s the application alerts.", state)
+                self.app.DisplayAlerts = display_alerts
+
+    def close_document(self, save_changes: bool = False) -> None:
+        """Close the active document and app (if open).
+
+        :param save_changes: Enable to save changes on quit. (defaults to `False`)
+        """
+        if not self.app:  # no app open at all
+            return
+
+        if hasattr(self.app, "ActiveDocument"):
+            state = "saving" if save_changes else "not saving"
+            self.logger.debug("Closing the opened document and %s changes.", state)
+            with catch_com_error():
+                self.app.ActiveDocument.Close(save_changes)
+
+    def quit_application(self, save_changes: bool = False) -> None:
+        """Quit the application.
+
+        :param save_changes: Enable to save changes on quit. (defaults to False)
+        """
+        if not self.app:
+            return
+
+        self.close_document(save_changes)
+        with catch_com_error():
+            self.app.Quit()
+        self.app = None

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -81,11 +81,14 @@ class BaseApplication(metaclass=MetaApplication):
 
     This library works on a Windows operating system with UI enabled only, and you must
     ensure that you open the app first with ``Open Application`` before running any
-    other relevant keyword which requires to operate on an open app. Check the
-    documentation below for more info:
+    other relevant keyword which requires to operate on an open app. The application is
+    automatically closed at the end of the task execution, so this can be changed by
+    importing the library with the `autoexit=${False}` setting.
 
-    - https://robocorp.com/docs/control-room/unattended/worker-setups/windows-desktop
-    - https://robocorp.com/docs/faq/windows-server-2016
+    .. code-block:: robotframework
+
+        *** Settings ***
+        Library     RPA.Excel|Outlook|Word.Application    autoexit=${False}
 
     If you're running the Process by Control Room through a custom self-hosted Worker
     service, then please make sure that you enable an RDP session by ticking "Use
@@ -93,6 +96,11 @@ class BaseApplication(metaclass=MetaApplication):
 
     If you still encounter issues with opening a document, please ensure that file can
     be opened first manually and dismiss any alert potentially blocking the process.
+
+    Check the documentation below for more info:
+
+    - https://robocorp.com/docs/control-room/unattended/worker-setups/windows-desktop
+    - https://robocorp.com/docs/faq/windows-server-2016
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
@@ -140,17 +148,23 @@ class BaseApplication(metaclass=MetaApplication):
                 state = "visible" if visible else "invisible"
                 self.logger.debug("Making the application %s.", state)
                 self.app.Visible = visible
+            elif visible:
+                self.logger.warning("Visibility cannot be controlled on this app.")
 
             # Show for e.g. a file overwrite warning or not.
             if hasattr(self.app, "DisplayAlerts"):
                 state = "Displaying" if display_alerts else "Hiding"
                 self.logger.debug("%s the application alerts.", state)
                 self.app.DisplayAlerts = display_alerts
+            elif display_alerts:
+                self.logger.warning(
+                    "Alerts displaying cannot be controlled on this app."
+                )
 
     @property
     def _active_document(self):
         # Retrieves the currently active document. (raises COMError if there's none)
-        return self.app.ActiveDocument
+        return getattr(self.app, "ActiveDocument", None)
 
     def _deactivate_document(self):
         # Cleans-up a just closed previously active document.

--- a/packages/main/tests/robot/test_browser.robot
+++ b/packages/main/tests/robot/test_browser.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Library             Collections
 Library             OperatingSystem
 Library             RPA.Browser.Selenium    locators_path=${LOCATORS}
 Library             RPA.FileSystem
@@ -17,8 +18,34 @@ ${RESULTS}          ${CURDIR}${/}..${/}results
 ${BROWSER_DATA}     ${RESULTS}${/}browser
 ${LOCATORS}         ${RESOURCES}${/}locators.json
 ${ALERT_HTML}       file://${RESOURCES}${/}alert.html
-${USER_AGENT}
-...                 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1337.0.0.0 Safari/1337.36
+${USER_AGENT}       Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1337.0.0.0 Safari/1337.36
+
+
+*** Keywords ***
+My Custom Keyword
+    Get Value    id:notexist
+
+Create Browser Data Directory
+    ${data_dir} =    Absolute Path    ${BROWSER_DATA}
+    RPA.FileSystem.Create Directory    ${data_dir}    parents=${True}
+    RETURN    ${data_dir}
+
+Download With Specific Browser
+    [Arguments]    ${browser}
+    Close Browser
+
+    Set Download Directory    ${OUTPUT_DIR}
+    Open Available Browser    https://robocorp.com/docs/security
+    ...    browser_selection=${browser}
+    ...    headless=${True}    # PDF downloading now works in headless as well
+    Click Link    Data protection whitepaper
+
+    ${file_path} =    Set Variable
+    ...    ${OUTPUT_DIR}${/}security-and-data-protection-whitepaper.pdf
+    Wait Until Keyword Succeeds    3x    1s    File Should Exist    ${file_path}
+
+    [Teardown]    Run Keyword And Ignore Error
+    ...    RPA.FileSystem.Remove File    ${file_path}
 
 
 *** Tasks ***
@@ -35,12 +62,15 @@ Does alert not contain
     Handle Alert    DISMISS
 
 Screenshot Robocorp Google search result
-    [Tags]    skip
     # NOTE(cmin764): As of 19.05.2023 this test passes in CI, Mac, Windows and
-    #    Control Room, without any consent popup blocker.
+    #  Control Room, without any consent popup blocker.
     # NOTE(mikahanninen): Skipped on 02.06.2023 as this fails on
-    # local build on consent form which for me is also using Finnish Google site.
+    #  local build on consent form which for me is also using Finnish Google site.
+    [Tags]  skip  # since this relies on English language
     Go To    www.google.com
+    Click Element If Visible    No thanks
+    Click Element If Visible    xpath://button/div[contains(text(), 'I agree')]
+    Click Element If Visible    xpath://button/div[contains(text(), 'Reject all')]
     Wait Until Element Is Visible    q
 
     Input Text    q    Robocorp
@@ -86,14 +116,6 @@ Print page as PDF document
     [Teardown]    Run Keyword And Ignore Error
     ...    RPA.FileSystem.Remove File    ${output_path}
 
-Download PDF in custom Chrome directory
-    [Tags]    skip    # flaky test in CI, mainly on Windows with Python 3.7, 3.8
-    Download With Specific Browser    Chrome
-
-Download PDF in custom Firefox directory
-    [Tags]    skip    # no support for the Firefox browser in CI
-    Download With Specific Browser    Firefox
-
 Highlight elements
     [Setup]    Go To    https://robocorp.com/docs/quickstart-guide
 
@@ -115,47 +137,6 @@ Mute browser failures
     Mute run on failure    My Custom Keyword
     Run keyword and expect error    *    My Custom Keyword
     Run keyword and expect error    *    Get Value    id:notexist
-
-Open In Incognito With Custom Options
-    [Documentation]    Test Chrome with custom options (incognito), port and explicit
-    ...    profile directory.
-    [Setup]    Close Browser
-    # NOTE(cmin764): In CI, Chrome may attract a buggy webdriver which makes the custom
-    #    profile usage to break in headless mode. (unknown error: unable to discover open
-    #    pages)
-#    [Tags]    skip
-
-    ${data_dir} =    Create Browser Data Directory
-    ${options} =    Set Variable    add_argument("--incognito")
-
-    Open Available Browser    https://robocorp.com    browser_selection=Chrome
-    ...    headless=${True}    options=${options}    port=${18888}
-    # Custom profile usage now works in headless mode as well. (but not guaranteed
-    #    with older browser versions)
-    ...    use_profile=${True}    profile_path=${data_dir}
-
-    ${visible} =    Is Element Visible    xpath://button[2]
-    Should Be True    ${visible}
-    Directory Should Not Be Empty    ${data_dir}
-
-    Close Browser
-    [Teardown]    RPA.FileSystem.Remove directory    ${data_dir}    recursive=${True}
-
-Open Browser With Dict Options
-    [Setup]    Close Browser
-
-    @{args} =    Create List    --headless=new
-    &{caps} =    Create Dictionary    acceptInsecureCerts    ${True}
-    &{options} =    Create Dictionary    arguments    ${args}    capabilities    ${caps}
-
-    ${driver_path} =    Evaluate    RPA.core.webdriver.download("Chrome")
-    ...    modules=RPA.core.webdriver
-    Log To Console    Downloaded webdriver path: ${driver_path}
-
-    Open Browser    https://robocorp.com    browser=Chrome    options=${options}
-    ...    executable_path=${driver_path}
-    ${visible} =    Is Element Visible    xpath://button[2]
-    Should Be True    ${visible}
 
 Get and set an attribute
     [Setup]    Go To    https://robotsparebinindustries.com/
@@ -191,29 +172,52 @@ Test Shadow Root
     ${text} =    Get Text    ${elem}
     Should Be Equal    ${text}    some text
 
+Download PDF in custom Firefox directory
+    [Tags]    skip    # no support for the Firefox browser in CI
+    Download With Specific Browser    Firefox
 
-*** Keywords ***
-My Custom Keyword
-    Get Value    id:notexist
+Download PDF in custom Chrome directory
+    [Tags]    skip    # flaky test in CI, mainly on Windows with Python 3.7, 3.8
+    Download With Specific Browser    Chrome
 
-Create Browser Data Directory
-    ${data_dir} =    Absolute Path    ${BROWSER_DATA}
-    RPA.FileSystem.Create Directory    ${data_dir}    parents=${True}
-    RETURN    ${data_dir}
+Open Browser With Dict Options
+    [Setup]    Close Browser
 
-Download With Specific Browser
-    [Arguments]    ${browser}
+    @{args} =    Create List    --headless=new
+    &{caps} =    Create Dictionary    acceptInsecureCerts    ${True}
+    &{options} =    Create Dictionary
+    ...     arguments    ${args}
+    ...     capabilities    ${caps}
+
+    ${driver_path} =    Evaluate    RPA.core.webdriver.download("Chrome")
+    ...    modules=RPA.core.webdriver
+    Log To Console    Downloaded webdriver path: ${driver_path}
+
+    Open Browser    https://robocorp.com/docs    browser=Chrome    options=${options}
+    ...    executable_path=${driver_path}
+    ${visible} =    Is Element Visible    xpath://button[contains(@class, "desktop")]
+    Should Be True    ${visible}
+
+Open In Incognito With Custom Options
+    [Documentation]    Test Chrome with custom options (incognito), port and explicit
+    ...    profile directory.
+    [Setup]    Close Browser
+    # NOTE(cmin764): In CI, Chrome may attract a buggy webdriver which makes the custom
+    #  profile usage to break in headless mode. (unknown error: unable to discover open
+    #  pages)
+
+    ${data_dir} =    Create Browser Data Directory
+    ${options} =    Set Variable    add_argument("--incognito")
+
+    Open Available Browser    https://robocorp.com/docs    browser_selection=Chrome
+    ...    headless=${True}    options=${options}    port=${18888}
+    # Custom profile usage now works in headless mode as well. (but not guaranteed
+    #    with older browser versions)
+    ...    use_profile=${True}    profile_path=${data_dir}
+
+    ${visible} =    Is Element Visible    xpath://button[contains(@class, "desktop")]
+    Should Be True    ${visible}
+    Directory Should Not Be Empty    ${data_dir}
+
     Close Browser
-
-    Set Download Directory    ${OUTPUT_DIR}
-    Open Available Browser    https://robocorp.com/docs/security
-    ...    browser_selection=${browser}
-    ...    headless=${True}    # PDF downloading now works in headless as well
-    Click Link    Data protection whitepaper
-
-    ${file_path} =    Set Variable
-    ...    ${OUTPUT_DIR}${/}security-and-data-protection-whitepaper.pdf
-    Wait Until Keyword Succeeds    3x    1s    File Should Exist    ${file_path}
-
-    [Teardown]    Run Keyword And Ignore Error
-    ...    RPA.FileSystem.Remove File    ${file_path}
+    [Teardown]    RPA.FileSystem.Remove directory    ${data_dir}    recursive=${True}

--- a/packages/main/tests/robot/test_browser.robot
+++ b/packages/main/tests/robot/test_browser.robot
@@ -64,13 +64,11 @@ Does alert not contain
 Screenshot Robocorp Google search result
     # NOTE(cmin764): As of 19.05.2023 this test passes in CI, Mac, Windows and
     #  Control Room, without any consent popup blocker.
-    # NOTE(mikahanninen): Skipped on 02.06.2023 as this fails on
-    #  local build on consent form which for me is also using Finnish Google site.
-    [Tags]  skip  # since this relies on English language
+    # NOTE(mikahanninen): Skipped on 02.06.2023 as this fails on the local build on
+    #  consent form, which for me is also using the Finnish Google site.
+    [Tags]  skip  # since this might fail in the future if the website changes
     Go To    www.google.com
-    Click Element If Visible    No thanks
-    Click Element If Visible    xpath://button/div[contains(text(), 'I agree')]
-    Click Element If Visible    xpath://button/div[contains(text(), 'Reject all')]
+    Click Element If Visible    xpath://button[2]  # test fails if this is missed
     Wait Until Element Is Visible    q
 
     Input Text    q    Robocorp
@@ -162,7 +160,7 @@ Test enhanced clicking
     Does Alert Contain    after
 
 Test Shadow Root
-    [Tags]    skip    # flaky test during async runs
+    [Tags]    skip  # flaky test during async runs
     [Setup]    Is Alert Present
 
     Go To    http://watir.com/examples/shadow_dom.html
@@ -173,17 +171,18 @@ Test Shadow Root
     Should Be Equal    ${text}    some text
 
 Download PDF in custom Firefox directory
-    [Tags]    skip    # no support for the Firefox browser in CI
+    [Tags]    manual  # no support for the Firefox browser in CI (or on dev machine)
     Download With Specific Browser    Firefox
 
 Download PDF in custom Chrome directory
-    [Tags]    skip    # flaky test in CI, mainly on Windows with Python 3.7, 3.8
+    [Tags]    skip  # flaky test in CI, mainly on Windows with Python 3.7, 3.8
     Download With Specific Browser    Chrome
 
 Open Browser With Dict Options
+    [Tags]    skip  # flaky test in CI, on Windows and Linux, but not on Mac
     [Setup]    Close Browser
 
-    @{args} =    Create List    --headless=new
+    @{args} =    Create List    --headless=new  # this is a newly introduced argument
     &{caps} =    Create Dictionary    acceptInsecureCerts    ${True}
     &{options} =    Create Dictionary
     ...     arguments    ${args}

--- a/packages/main/tests/robot/test_excel_application.robot
+++ b/packages/main/tests/robot/test_excel_application.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Library         OperatingSystem
 Library         RPA.Excel.Application   autoexit=${False}
 
 Suite Setup         Open Application    visible=${True}     display_alerts=${True}
@@ -10,6 +11,7 @@ Default Tags      windows   skip  # no Excel app in CI
 *** Variables ***
 ${RESOURCES}    ${CURDIR}${/}..${/}resources
 ${EXCELS}       ${RESOURCES}${/}excels
+${RESULTS}      ${CURDIR}${/}..${/}results
 
 
 *** Tasks ***
@@ -18,5 +20,8 @@ Run a macro on a strange name
     [Setup]     Open Workbook    ${EXCELS}${/}boldmacro-x.xlsm
 
     Run Macro    bold_column  # this was failing before (just because of the file name)
+    ${out_pdf} =    Set Variable    ${RESULTS}${/}boldmacro-x.pdf
+    Export As PDF   ${out_pdf}
+    File Should Exist   ${out_pdf}
 
     [Teardown]  Close Document

--- a/packages/main/tests/robot/test_excel_application.robot
+++ b/packages/main/tests/robot/test_excel_application.robot
@@ -1,10 +1,10 @@
 *** Settings ***
-Library         RPA.Excel.Application
+Library         RPA.Excel.Application   autoexit=${False}
 
-Task Setup      Open Application
-Task Teardown   Quit Application
+Suite Setup         Open Application    visible=${True}     display_alerts=${True}
+Suite Teardown      Quit Application
 
-Force tags      windows  skip
+Default Tags      windows   skip  # no Excel app in CI
 
 
 *** Variables ***
@@ -13,7 +13,10 @@ ${EXCELS}       ${RESOURCES}${/}excels
 
 
 *** Tasks ***
-Run Macro On Strange Name
+Run a macro on a strange name
     # The `-` in the name created issues.
-    Open Workbook    ${EXCELS}${/}boldmacro-x.xlsm
+    [Setup]     Open Workbook    ${EXCELS}${/}boldmacro-x.xlsm
+
     Run Macro    bold_column  # this was failing before (just because of the file name)
+
+    [Teardown]  Close Document

--- a/packages/main/tests/robot/test_outlook_application.robot
+++ b/packages/main/tests/robot/test_outlook_application.robot
@@ -1,24 +1,35 @@
 *** Settings ***
-Library         RPA.Outlook.Application
+Library         Collections
+Library         RPA.Outlook.Application   autoexit=${False}
 
-Default Tags    skip
+Suite Setup         Open Application    visible=${True}     display_alerts=${True}
+Suite Teardown      Quit Application
+
+Default Tags      windows   skip  # no Outlook app in CI
+
+
+*** Variables ***
+${RESOURCES}    ${CURDIR}${/}..${/}resources
 
 
 *** Tasks ***
 Save email as draft
-    Open Application
     Send Email    recipient@domain.com    Drafted message    Containing draft body
-    ...    attachments=${CURDIR}${/}test_outlook_application.robot
-    ...    save_as_draft=True
+    ...    attachments=${RESOURCES}${/}vero2.pdf
+    ...    save_as_draft=${True}
 
 Send email with cc recipients
-    Open Application
-    Sleep    15s
-    ${cc}=    Create List    robocorp.developer@gmail.com    robocorp.tester@gmail.com
+    ${cc} =    Create List    robocorp.developer@gmail.com    robocorp.tester@gmail.com
     Send Email
-    ...    mika@robocorp.com;robocorp.tester@gmail.com
+    ...    mika@robocorp.com;cosmin@robocorp.com;robocorp.tester@gmail.com
     ...    All recipient fields - message from rpaframwork tests - part 3
     ...    Contained body
-    ...    attachments=${CURDIR}${/}test_outlook_application.robot;${CURDIR}${/}test_calendar.robot
+    ...    attachments=${RESOURCES}${/}vero2.pdf;${RESOURCES}${/}invoice.png
     ...    cc_recipients=${cc}
     ...    bcc_recipients=robocorp.tester.2@gmail.com;mika@beissi.onmicrosoft.com
+
+Retrieve emails
+    @{emails} =     Get Emails      folder_name=Sent Items
+    Log List    ${emails}
+    ${length} =     Get Length    ${emails}
+    Log To Console    Sent e-mails: ${length}

--- a/packages/main/tests/robot/test_word_application.robot
+++ b/packages/main/tests/robot/test_word_application.robot
@@ -1,15 +1,38 @@
 *** Settings ***
-Library         RPA.Word.Application
-Force tags      windows  skip
-Task Setup      Open Application
-Task Teardown   Quit Application
+Library     RPA.Word.Application    autoexit=${False}
+
+Suite Setup         Open Application    visible=${True}     display_alerts=${True}
+Suite Teardown      Quit Application
+
+Default Tags      windows   skip  # no Word app in CI
+
+
+*** Variables ***
+${RESULTS}      ${CURDIR}${/}..${/}results
+${DOC}          ${RESULTS}${/}robocorp_story.docx
+
+
+*** Keywords ***
+Ensure Document
+    Create New Document
+
+    Set Header          11.03.2020
+    Write Text          This is an educational story of a company called Robocorp.
+    Set Footer          Author: Mika Hänninen
+    Save Document As    ${DOC}
+
+    [Teardown]      Close Document      save_changes=${True}
+
 
 *** Tasks ***
-Creating new document
-    Create New Document
-    Write Text          This is an educational story of company called Robocorp.
-    Set Header          11.03.2020
-    Set Footer          Author: Mika Hänninen
+Create document and export as PDF
+    [Setup]     Ensure Document
+
+    Open File    ${DOC}     read_only=${False}
+    ${out_pdf} =    Set Variable    ${RESULTS}${/}robocorp_story.pdf
+    Export To PDF   ${out_pdf}  # export initially as it is
     Replace Text        educational  inspirational
-    Save Document As    robocorp_story.docx
-    Export to pdf       robocorp_story.pdf
+    Export To PDF   ${out_pdf}  # export one more time to check replacement
+    Log To Console      Output PDF: ${out_pdf}
+
+    [Teardown]      Close Document  # not saving changes this time

--- a/packages/windows/tests/robot/test_windows.robot
+++ b/packages/windows/tests/robot/test_windows.robot
@@ -6,7 +6,7 @@ Library           String
 
 Test Setup      Set Wait Time    0.7
 
-Default Tags      skip
+Default Tags      windows   skip
 
 
 *** Variables ***

--- a/poetry.lock
+++ b/poetry.lock
@@ -335,18 +335,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.28.24"
+version = "1.28.29"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.24-py3-none-any.whl", hash = "sha256:0300ca6ec8bc136eb316b32cc1e30c66b85bc497f5a5fe42e095ae4280569708"},
-    {file = "boto3-1.28.24.tar.gz", hash = "sha256:9d1b4713c888e53a218648ad71522bee9bec9d83f2999fff2494675af810b632"},
+    {file = "boto3-1.28.29-py3-none-any.whl", hash = "sha256:7b8e7deee9f665612b3cd7412989aaab0337d8006a0490a188c814af137bd32d"},
+    {file = "boto3-1.28.29.tar.gz", hash = "sha256:1ab375c231547db4c9ce760e29cbe90d0341fe44910571b1bc4967a72fd8276f"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.24,<1.32.0"
+botocore = ">=1.31.29,<1.32.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -355,14 +355,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.24"
+version = "1.31.29"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.24-py3-none-any.whl", hash = "sha256:8c7ba9b09e9104e2d473214e1ffcf84b77e04cf6f5f2344942c1eed9e299f947"},
-    {file = "botocore-1.31.24.tar.gz", hash = "sha256:2d8f412c67f9285219f52d5dbbb6ef0dfa9f606da29cbdd41b6d6474bcc4bbd4"},
+    {file = "botocore-1.31.29-py3-none-any.whl", hash = "sha256:d3dc422491b3a30667f188f3434541a1dd86d6f8ed7f98ca26e056ae7d912c85"},
+    {file = "botocore-1.31.29.tar.gz", hash = "sha256:71b335a47ee061994ac12f15ffe63c5c783cb055dc48079b7d755a46b9c1918c"},
 ]
 
 [package.dependencies]
@@ -585,14 +585,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.6"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
-    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]
@@ -758,14 +758,14 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
-    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 
 [package.extras]
@@ -1107,14 +1107,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.96.0"
+version = "2.97.0"
 description = "Google API Client Library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-python-client-2.96.0.tar.gz", hash = "sha256:f712373d03d338af57b9f5fe98c91f4b5baaa8765469b015bc623c4681c5bd51"},
-    {file = "google_api_python_client-2.96.0-py2.py3-none-any.whl", hash = "sha256:38c2b61b10d15bb41ec8f89303e3837ec2d2c3e4e38de5800c05ee322492f937"},
+    {file = "google-api-python-client-2.97.0.tar.gz", hash = "sha256:48277291894876a1ca7ed4127e055e81f81e6343ced1b544a7200ae2c119dcd7"},
+    {file = "google_api_python_client-2.97.0-py2.py3-none-any.whl", hash = "sha256:5215f4cd577753fc4192ccfbe0bb8b55d4bb5fd68fa6268ac5cf271b6305de31"},
 ]
 
 [package.dependencies]
@@ -1227,14 +1227,14 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4
 
 [[package]]
 name = "google-cloud-language"
-version = "2.10.1"
+version = "2.11.0"
 description = "Google Cloud Language API client library"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-language-2.10.1.tar.gz", hash = "sha256:140c0753585a45977bb9c7d1c707e7f8ab5633cff56bded9ef852f9016b732af"},
-    {file = "google_cloud_language-2.10.1-py2.py3-none-any.whl", hash = "sha256:c971572b436e0946b3fb7467da138c78f08498ce32413a4600550ca9d6b42efb"},
+    {file = "google-cloud-language-2.11.0.tar.gz", hash = "sha256:95d235f503d904e8854117e928ef36ac930c24825fcb8400c3f368a908fdbe14"},
+    {file = "google_cloud_language-2.11.0-py2.py3-none-any.whl", hash = "sha256:cdcc83dac47c5268140429af584844f3a913301f4195883b134d2690cde69308"},
 ]
 
 [package.dependencies]
@@ -3229,14 +3229,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "3.15.0"
+version = "3.15.1"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "pypdf-3.15.0-py3-none-any.whl", hash = "sha256:2e29ddb62561ec91157c784783714703ddd3ce08f070ecbc57404fb86cd9fc97"},
-    {file = "pypdf-3.15.0.tar.gz", hash = "sha256:8a6264e1c47c63dc2484e29bdfa76b121435896a84e94b7c5ae82c6ae96354bb"},
+    {file = "pypdf-3.15.1-py3-none-any.whl", hash = "sha256:99b337af7da8046d1e2e94354846e8c56753e1cdc817ac0fbe770c1e2281902b"},
+    {file = "pypdf-3.15.1.tar.gz", hash = "sha256:d0dfaf4f10dfb06ac39e1d6a9cbffd63e77621d1e89c0ef08f346fd902df7b4b"},
 ]
 
 [package.dependencies]
@@ -4084,7 +4084,7 @@ files = [
 
 [[package]]
 name = "rpaframework"
-version = "25.0.1"
+version = "26.0.0"
 description = "A collection of tools and libraries for RPA"
 category = "main"
 optional = false
@@ -4456,14 +4456,14 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3transfer"
-version = "0.6.1"
+version = "0.6.2"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "s3transfer-0.6.1-py3-none-any.whl", hash = "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346"},
-    {file = "s3transfer-0.6.1.tar.gz", hash = "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"},
+    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
+    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
 ]
 
 [package.dependencies]
@@ -4508,19 +4508,19 @@ urllib3 = {version = ">=1.26,<3", extras = ["socks"]}
 
 [[package]]
 name = "setuptools"
-version = "68.0.0"
+version = "68.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
-    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+    {file = "setuptools-68.1.0-py3-none-any.whl", hash = "sha256:e13e1b0bc760e9b0127eda042845999b2f913e12437046e663b833aa96d89715"},
+    {file = "setuptools-68.1.0.tar.gz", hash = "sha256:d59c97e7b774979a5ccb96388efc9eb65518004537e85d52e81eaee89ab6dd91"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -4858,14 +4858,14 @@ files = [
 
 [[package]]
 name = "tenacity"
-version = "8.2.2"
+version = "8.2.3"
 description = "Retry code until it succeeds"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "tenacity-8.2.2-py3-none-any.whl", hash = "sha256:2f277afb21b851637e8f52e6a613ff08734c347dc19ade928e519d7d2d8569b0"},
-    {file = "tenacity-8.2.2.tar.gz", hash = "sha256:43af037822bd0029025877f3b2d97cc4d7bb0c2991000a3d59d71517c5c969e0"},
+    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
+    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
 ]
 
 [package.extras]


### PR DESCRIPTION
Closes #1055 

Through such a common reused structure, we're ensured we have an aligned app management when handling errors. (also aids further development)

### ToDo
- [x] Do the refactoring for `Word` as well.
- [x] Fix the rest of the linked [Issue](https://github.com/robocorp/rpaframework/issues/1055) bullet-points.
- [x] Increase robot testing coverage.
- [ ] Add tested dual comprehensive docs.
- [x] Check `COMError` importing and docs building behaviour. (exclude base _application.py_ module; no `app` keyword)
- [x] Bump major version, add breaking release notes and Poetry update **main** and **meta**.

### Unplanned
- Fixed `Selenium` library and its tests in order to pass CI.