### PR TITLE
`RPA.Cloud.Google` New keywords for Sheets

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -15,6 +15,18 @@ Latest versions
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+04 Sep 2023
+-----------
+
+- Library **RPA.Cloud.Google** (:pr:`1082`; ``rpaframework-google`` **7.2.0**):
+
+  - Add new keywords for Google Sheets
+
+    - ``Get sheet basic information``
+    - ``Get sheet details``
+    - ``Get all sheet values``
+    - ``To column letter``
+
 24 Aug 2023
 -----------
 

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -18,14 +18,31 @@ Latest versions
 04 Sep 2023
 -----------
 
-- Library **RPA.Cloud.Google** (:pr:`1082`; ``rpaframework-google`` **7.2.0**):
+- Library **RPA.Cloud.Google** (:pr:`1082`; ``rpaframework-google`` **8.0.0**):
 
   - Add new keywords for Google Sheets
 
-    - ``Get sheet basic information``
-    - ``Get sheet details``
+    - ``Copy spreadsheet``
+    - ``Create spreadsheet``
+    - ``Delete sheet``
+    - ``Generic spreadsheet batch update``
     - ``Get all sheet values``
+    - ``Get spreadsheet basic information``
+    - ``Get spreadsheet details``
+    - ``Rename sheet``
     - ``To column letter``
+
+  - Repurposed keywords
+
+    - ``Copy sheet`` (now will copy a sheet within a spreadsheet)
+    - ``Create sheet`` (now will create a sheet within a spreadsheet)
+
+  .. warning::
+    **Breaking** changes in the ``Sheets`` keywords. All actions/properties
+    related to a whole spreadsheet will use `spreadsheet` name and `sheet` will
+    be used to indicate a single sheet in a spreadsheet. This is to be consistent
+    with Google API naming.
+
 
 24 Aug 2023
 -----------

--- a/packages/google/poetry.lock
+++ b/packages/google/poetry.lock
@@ -1785,14 +1785,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.4.0"
+version = "7.4.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
-    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+    {file = "pytest-7.4.1-py3-none-any.whl", hash = "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"},
+    {file = "pytest-7.4.1.tar.gz", hash = "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab"},
 ]
 
 [package.dependencies]
@@ -2084,14 +2084,14 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "selenium"
-version = "4.11.2"
+version = "4.12.0"
 description = ""
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "selenium-4.11.2-py3-none-any.whl", hash = "sha256:98e72117b194b3fa9c69b48998f44bf7dd4152c7bd98544911a1753b9f03cc7d"},
-    {file = "selenium-4.11.2.tar.gz", hash = "sha256:9f9a5ed586280a3594f7461eb1d9dab3eac9d91e28572f365e9b98d9d03e02b5"},
+    {file = "selenium-4.12.0-py3-none-any.whl", hash = "sha256:b2c48b1440db54a0653300d9955f5421390723d53b36ec835e18de8e13bbd401"},
+    {file = "selenium-4.12.0.tar.gz", hash = "sha256:95be6aa449a0ab4ac1198bb9de71bbe9170405e04b9752f4b450dc7292a21828"},
 ]
 
 [package.dependencies]

--- a/packages/google/pyproject.toml
+++ b/packages/google/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-google"
-version = "7.1.2"
+version = "7.2.0"
 description = "Google library for RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/google/pyproject.toml
+++ b/packages/google/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-google"
-version = "7.2.0"
+version = "8.0.0"
 description = "Google library for RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
+++ b/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
@@ -330,7 +330,7 @@ class SheetsKeywords(LibraryContext):
         return self.service.spreadsheets().get(spreadsheetId=sheet_id).execute()
 
     @keyword(tags=["sheets"])
-    def to_A1_notation(self, number):
+    def to_A1_notation(self, number: int):
         """
         Convert a number into its Excel A1 notation character(s).
 

--- a/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
+++ b/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
@@ -44,13 +44,19 @@ class SheetsKeywords(LibraryContext):
         )
 
     @keyword(tags=["sheets"])
-    def create_sheet(self, title: str) -> str:
+    def create_spreadsheet(self, title: str) -> str:
         """Create empty sheet with a title
 
         :param title: name as string
-        :return: created `sheet_id`
+        :return: created `spreadsheet_id`
 
         **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.create_spreadsheet("name of the spreadsheet")
 
         **Robot Framework**
 
@@ -72,7 +78,7 @@ class SheetsKeywords(LibraryContext):
     @keyword(tags=["sheets"])
     def insert_sheet_values(
         self,
-        sheet_id: str,
+        spreadsheet_id: str,
         sheet_range: str,
         values: list,
         major_dimension: str = "COLUMNS",
@@ -80,7 +86,7 @@ class SheetsKeywords(LibraryContext):
     ) -> Dict:
         """Insert values into sheet cells
 
-        :param sheet_id: target spreadsheet
+        :param spreadsheet_id: target spreadsheet
         :param sheet_range: target sheet range
         :param values: list of values to insert into sheet
         :param major_dimension: major dimension of the values, default `COLUMNS`
@@ -90,20 +96,27 @@ class SheetsKeywords(LibraryContext):
 
         **Examples**
 
+        **Python**
+
+        .. code-block:: python
+
+            values = [[11, 12, 13], ['aa', 'bb', 'cc']]
+            result = GOOGLE.insert_sheet_values(spreadsheet_id, "A:C", values)
+
         **Robot Framework**
 
         .. code-block:: robotframework
 
             ${values}   Evaluate   [[11, 12, 13], ['aa', 'bb', 'cc']]
-            ${result}=  Insert Sheet Values   ${SHEET_ID}  A:B  ${values}
-            ${result}=  Insert Sheet Values   ${SHEET_ID}  A:B  ${values}  ROWS
+            ${result}=  Insert Sheet Values   ${SPREADSHEET_ID}  A:B  ${values}
+            ${result}=  Insert Sheet Values   ${SPREADSHEET_ID}  A:B  ${values}  ROWS
         """
         resource = {"majorDimension": major_dimension, "values": values}
         return (
             self.service.spreadsheets()
             .values()
             .append(
-                spreadsheetId=sheet_id,
+                spreadsheetId=spreadsheet_id,
                 range=sheet_range,
                 body=resource,
                 valueInputOption=value_input_option,
@@ -114,7 +127,7 @@ class SheetsKeywords(LibraryContext):
     @keyword(tags=["sheets"])
     def update_sheet_values(
         self,
-        sheet_id: str,
+        spreadsheet_id: str,
         sheet_range: str,
         values: list,
         major_dimension: str = "COLUMNS",
@@ -122,7 +135,7 @@ class SheetsKeywords(LibraryContext):
     ) -> Dict:
         """Insert values into sheet cells
 
-        :param sheet_id: target spreadsheet
+        :param spreadsheet_id: target spreadsheet
         :param sheet_range: target sheet range
         :param values: list of values to insert into sheet
         :param major_dimension: major dimension of the values, default `COLUMNS`
@@ -132,19 +145,35 @@ class SheetsKeywords(LibraryContext):
 
         **Examples**
 
+        **Python**
+
+        .. code-block:: python
+
+            row_data = [[11, 12, 13], ['aa', 'bb', 'cc']]
+            result = GOOGLE.update_sheet_values(
+                spreadsheet_id,
+                "A1:C1",
+                row_data,
+                "ROWS
+                )
+
         **Robot Framework**
 
         .. code-block:: robotframework
 
             ${row}  Evaluate   [[22, 33 ,44]]
-            ${result}=  Update Sheet Values  ${SHEET_ID}  A6:C6  ${row}   ROWS
+            ${result}=  Update Sheet Values
+            ...   ${SPREADSHEET_ID}
+            ...   A6:C6
+            ...   ${row}
+            ...   ROWS
         """
         resource = {"majorDimension": major_dimension, "values": values}
         return (
             self.service.spreadsheets()
             .values()
             .update(
-                spreadsheetId=sheet_id,
+                spreadsheetId=spreadsheet_id,
                 range=sheet_range,
                 body=resource,
                 valueInputOption=value_input_option,
@@ -155,14 +184,14 @@ class SheetsKeywords(LibraryContext):
     @keyword(tags=["sheets"])
     def get_sheet_values(
         self,
-        sheet_id: str,
+        spreadsheet_id: str,
         sheet_range: str = None,
         value_render_option: str = "UNFORMATTED_VALUE",
         datetime_render_option: str = "FORMATTED_STRING",
     ) -> List:
         """Get values from the range in the spreadhsheet
 
-        :param sheet_id: target spreadsheet
+        :param spreadsheet_id: target spreadsheet
         :param sheet_range: target sheet range
         :param value_render_option: how values should be represented
          in the output defaults to "UNFORMATTED_VALUE"
@@ -172,14 +201,20 @@ class SheetsKeywords(LibraryContext):
 
         **Examples**
 
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.get_sheet_values(spreadsheet_id, "A1:C1")
+
         **Robot Framework**
 
         .. code-block:: robotframework
 
-            ${values}=  Get Sheet Values  ${SHEET_ID}  A1:C1
+            ${values}=  Get Sheet Values  ${SPREADSHEET_ID}  A1:C1
         """  # noqa: E501
         parameters = {
-            "spreadsheetId": sheet_id,
+            "spreadsheetId": spreadsheet_id,
             "range": sheet_range,
             "valueRenderOption": value_render_option,
             "dateTimeRenderOption": datetime_render_option,
@@ -190,14 +225,14 @@ class SheetsKeywords(LibraryContext):
     @keyword(tags=["sheets"])
     def get_all_sheet_values(
         self,
-        sheet_id: str,
+        spreadsheet_id: str,
         sheet_name: str = None,
         value_render_option: str = "UNFORMATTED_VALUE",
         datetime_render_option: str = "FORMATTED_STRING",
     ) -> List:
         """Get values from the range in the spreadsheet
 
-        :param sheet_id: target spreadsheet
+        :param spreadsheet_id: target spreadsheet
         :param sheet_name: target sheet (default first sheet)
         :param value_render_option: how values should be represented
          in the output defaults to "UNFORMATTED_VALUE"
@@ -207,6 +242,12 @@ class SheetsKeywords(LibraryContext):
 
         **Examples**
 
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.get_all_sheet_values(spreadsheet_id)
+
         **Robot Framework**
 
         .. code-block:: robotframework
@@ -214,11 +255,11 @@ class SheetsKeywords(LibraryContext):
             ${values}=  Get All Sheet Values  ${SHEET_ID}  sheet1
         """  # noqa: E501
         parameters = {
-            "spreadsheetId": sheet_id,
+            "spreadsheetId": spreadsheet_id,
             "valueRenderOption": value_render_option,
             "dateTimeRenderOption": datetime_render_option,
         }
-        sheet_info = self.get_sheet_basic_information(sheet_id)
+        sheet_info = self.get_spreadsheet_basic_information(spreadsheet_id)
         if sheet_name:
             sheet_match = list(
                 filter(lambda sheet: sheet["title"] == sheet_name, sheet_info["sheets"])
@@ -237,58 +278,73 @@ class SheetsKeywords(LibraryContext):
         return self.service.spreadsheets().values().get(**parameters).execute()
 
     @keyword(tags=["sheets"])
-    def clear_sheet_values(self, sheet_id: str, sheet_range: str) -> Dict:
+    def clear_sheet_values(self, spreadsheet_id: str, sheet_range: str) -> Dict:
         """Clear cell values for range of cells within a spreadsheet
 
-        :param sheet_id: target spreadsheet
+        :param spreadsheet_id: target spreadsheet
         :param sheet_range: target sheet range
         :return: operation result
 
         **Examples**
 
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.clear_sheet_values(spreadsheet_id, "A1:C1")
+
         **Robot Framework**
 
         .. code-block:: robotframework
 
-            ${result}=  Clear Sheet Values  ${SHEET_ID}  A1:C1
+            ${result}=  Clear Sheet Values  ${SPREADSHEET_ID}  A1:C1
         """
         return (
             self.service.spreadsheets()
             .values()
             .clear(
-                spreadsheetId=sheet_id,
+                spreadsheetId=spreadsheet_id,
                 range=sheet_range,
             )
             .execute()
         )
 
     @keyword(tags=["sheets"])
-    def copy_sheet(self, sheet_id: str, target_sheet_id: str) -> Dict:
+    def copy_spreadsheet(self, spreadsheet_id: str, target_spreadsheet_id: str) -> Dict:
         """Copy spreadsheet to target spreadsheet
 
         *NOTE:* service account user must have access
         also to target spreadsheet
 
-        :param sheet_id: ID of the spreadsheet to copy
-        :param target_sheet_id: ID of the target spreadsheet
+        :param spreadsheet_id: ID of the spreadsheet to copy
+        :param target_spreadsheet_id: ID of the target spreadsheet
         :return: operation result
 
         **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.copy_spreadsheet(
+                spreadsheet_id,
+                source_spreadsheet_id,
+                target_spreadsheet_id)
 
         **Robot Framework**
 
         .. code-block:: robotframework
 
-            ${result}=  Copy Sheet   ${SHEET_ID}  ${NEW_SHEET}
+            ${result}=  Copy Spreadsheet   ${SPREADSHEET_ID}  ${ANOTHER_SPREADSHEET_ID}
         """
         body = {
-            "destination_spreadsheet_id": target_sheet_id,
+            "destination_spreadsheet_id": target_spreadsheet_id,
         }
         return (
             self.service.spreadsheets()
             .sheets()
             .copyTo(
-                spreadsheetId=sheet_id,
+                spreadsheetId=spreadsheet_id,
                 sheetId=0,
                 body=body,
             )
@@ -296,14 +352,14 @@ class SheetsKeywords(LibraryContext):
         )
 
     @keyword(tags=["sheets"])
-    def get_sheet_basic_information(self, sheet_id: str) -> List:
+    def get_spreadsheet_basic_information(self, spreadsheet_id: str) -> List:
         """Get title, id, url and sheets information
         from the spreadsheet.
 
-        :param sheet_id: ID of the spreadsheet
-        :return: operation result as a dictionary
+        :param spreadsheet_id: ID of the spreadsheet
+        :return: operation result as an dictionary
         """
-        result = self.get_sheet_details(sheet_id)
+        result = self.get_spreadsheet_details(spreadsheet_id)
         sheet_info = [
             {
                 "title": sheet["properties"]["title"],
@@ -321,24 +377,21 @@ class SheetsKeywords(LibraryContext):
         }
 
     @keyword(tags=["sheets"])
-    def get_sheet_details(self, sheet_id: str) -> Dict:
+    def get_spreadsheet_details(self, spreadsheet_id: str) -> Dict:
         """Returns spreadsheet information as a dictionary.
 
-        :param sheet_id: ID of the spreadsheet
-        :return: operation result as a dictionary
+        :param spreadsheet_id: ID of the spreadsheet
+        :return: operation result as an dictionary
         """
-        return self.service.spreadsheets().get(spreadsheetId=sheet_id).execute()
+        return self.service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
 
     @keyword(tags=["sheets"])
     def to_column_letter(self, number: int):
         """
-        Convert a number into its Excel A1 notation character(s).
+        Convert a column number into a column letter(s).
 
-        Parameters:
-        n (int): The 1-based index of the column
-
-        Returns:
-        str: The Excel column letter(s)
+        :param number: column number to convert
+        :return: column letter(s)
         """
         if number < 1:
             raise ValueError("Number must be greater than 0")
@@ -349,3 +402,260 @@ class SheetsKeywords(LibraryContext):
             column_letter = chr(65 + remainder) + column_letter
             number = (number - 1) // 26
         return column_letter
+
+    @keyword(tags=["sheets"])
+    def copy_sheet(
+        self,
+        spreadsheet_id: str,
+        source_sheet_name: str,
+        new_sheet_name: str,
+        insertSheetIndex: int = None,
+    ):
+        """Copy sheet into the spreadsheet as new sheet
+
+        :param spreadsheet_id: id of the spreadsheet
+        :param source_sheet_name: name of the source sheet
+        :param new_sheet_name: name for the new sheet
+        :param insertSheetIndex: zero based index where the new
+         sheet should be inserted, defaults to None
+        :return: operation result as an dictionary
+
+        **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.copy_sheet(
+                spreadsheet_id,
+                "Existing sheet",
+                "Copy of existing sheet"
+                )
+
+        **Robot Framework**
+
+        .. code-block:: robotframework
+
+            ${result}=    Copy Sheet
+            ...   ${SPREADSHEET_ID}
+            ...   Existing sheet
+            ...   Copy of existing sheet
+        """
+        found_sheet = self.get_sheet_by_name(spreadsheet_id, source_sheet_name)
+
+        body = {
+            "requests": {
+                "duplicateSheet": {
+                    "sheetId": found_sheet["id"],
+                    "title": new_sheet_name,
+                }
+            }
+        }
+        if insertSheetIndex:
+            body["requests"]["duplicateSheet"]["insertSheetIndex"] = insertSheetIndex
+
+        return self.generic_spreadsheet_batch_update(spreadsheet_id, body)
+
+    @keyword(tags=["sheets"])
+    def create_sheet(self, spreadsheet_id: str, sheet_name: str):
+        """Create sheet into the spreadsheet
+
+        :param spreadsheet_id: id of the spreadsheet
+        :param sheet_name: name for the new sheet
+        :return: operation result as an dictionary
+
+        **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.create_sheet(spreadsheet_id, "New sheet")
+
+        **Robot Framework**
+
+        .. code-block:: robotframework
+
+            ${result}=    Create Sheet    ${SPREADSHEET_ID}    New sheet
+        """
+        body = {"requests": {"addSheet": {"properties": {"title": sheet_name}}}}
+        return self.generic_spreadsheet_batch_update(spreadsheet_id, body)
+
+    @keyword(tags=["sheets"])
+    def rename_sheet(self, spreadsheet_id: str, sheet_name: str, new_sheet_name: str):
+        """Rename sheet in the spreadsheet
+
+        :param spreadsheet_id: id of the spreadsheet
+        :param sheet_name: existing name of the sheet
+        :param new_sheet_name: name for the new sheet
+        :return: operation result as an dictionary
+
+        **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.rename_sheet(spreadsheet_id, "Sheet1", "New name")
+
+        **Robot Framework**
+
+        .. code-block:: robotframework
+
+            ${result}=    Rename Sheet    ${SPREADSHEET_ID}    Sheet1   New name
+        """
+        found_sheet = self.get_sheet_by_name(spreadsheet_id, sheet_name)
+
+        body = {
+            "requests": {
+                "updateSheetProperties": {
+                    "fields": "title",
+                    "properties": {
+                        "sheetId": found_sheet["id"],
+                        "title": new_sheet_name,
+                    },
+                }
+            }
+        }
+        return self.generic_spreadsheet_batch_update(spreadsheet_id, body)
+
+    @keyword(tags=["sheets"])
+    def delete_sheet(self, spreadsheet_id: str, sheet_name: str):
+        """Delete a sheet from the spreadsheet.
+
+        :param spreadsheet_id: id of the spreadsheet
+        :param sheet_name: name of the sheet to delete
+        :return: operation result as an dictionary
+
+        **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            result = GOOGLE.delete_sheet(spreadsheet_id, "Sheet1")
+
+        **Robot Framework**
+
+        .. code-block:: robotframework
+
+            ${result}=    Delete Sheet    ${SPREADSHEET_ID}    Sheet1
+        """
+        found_sheet = self.get_sheet_by_name(spreadsheet_id, sheet_name)
+
+        body = {"requests": {"deleteSheet": {"sheetId": found_sheet["id"]}}}
+        return self.generic_spreadsheet_batch_update(spreadsheet_id, body)
+
+    def get_sheet_by_name(self, spreadsheet_id: str, sheet_name: str):
+        sheet_info = self.get_spreadsheet_basic_information(spreadsheet_id)
+
+        sheet_match = list(
+            filter(lambda sheet: sheet["title"] == sheet_name, sheet_info["sheets"])
+        )
+        if len(sheet_match) != 1:
+            raise KeyError(f"Sheet '{sheet_name}' not found")
+        return sheet_match[0]
+
+    @keyword(tags=["sheets"])
+    def generic_spreadsheet_batch_update(self, spreadsheet_id: str, body: Dict):
+        """This keyword allows to do generic batch update to the spreadsheet.
+
+        For more information on the batch update:
+        https://googleapis.github.io/google-api-python-client/docs/dyn/sheets_v4.spreadsheets.html#create
+
+        List of possible requests actions (body can contain multiple at the same time):
+
+            - addBanding
+            - addChart
+            - addConditionalFormatRule
+            - addDataSource
+            - addDimensionGroup
+            - addFilterView
+            - addNamedRange
+            - addProtectedRange
+            - addSheet (keyword ``Create sheet``)
+            - addSlicer
+            - appendCells
+            - appendDimension
+            - autoFill
+            - autoResizeDimensions
+            - clearBasicFilter
+            - copyPaste
+            - createDeveloperMetadata
+            - cutPaste
+            - deleteBanding
+            - deleteConditionalFormatRule
+            - deleteDataSource
+            - deleteDeveloperMetadata
+            - deleteDimension
+            - deleteDimensionGroup
+            - deleteDuplicates
+            - deleteEmbeddedObject
+            - deleteFilterView
+            - deleteNamedRange
+            - deleteProtectedRange
+            - deleteRange
+            - deleteSheet (keyword ``Delete sheet``)
+            - duplicateFilterView
+            - duplicateSheet (keyword ``Copy sheet``)
+            - findReplace
+            - insertDimension
+            - insertRange
+            - mergeCells
+            - moveDimension
+            - pasteData
+            - randomizeRange
+            - refreshDataSource
+            - repeatCell
+            - setBasicFilter
+            - setDataValidation
+            - sortRange
+            - textToColumns
+            - trimWhitespace
+            - unmergeCells
+            - updateBanding
+            - updateBorders
+            - updateCells
+            - updateChartSpec
+            - updateConditionalFormatRule
+            - updateDataSource
+            - updateDeveloperMetadata
+            - updateDimensionGroup
+            - updateDimensionProperties
+            - updateEmbeddedObjectBorder
+            - updateEmbeddedObjectPosition
+            - updateFilterView
+            - updateNamedRange
+            - updateProtectedRange
+            - updateSheetProperties (keyword ``Rename sheet``)
+            - updateSlicerSpec
+            - updateSpreadsheetProperties
+
+        :param spreadsheet_id: id of the spreadsheet
+        :param body: body of the batch update request
+        :return: operation result as an dictionary
+
+        **Examples**
+
+        **Python**
+
+        .. code-block:: python
+
+            body = {"requests": {"deleteSheet": {"sheetId": "333555666"}}}
+            result = GOOGLE.generic_spreadsheet_batch_update(spreadsheet_id, body)
+
+        **Robot Framework**
+
+        .. code-block:: robotframework
+
+            ${body}=    Evaluate    {"requests": {"deleteSheet": {"sheetId": "333555666"}}}
+            ${result}=    Generic Spreadsheet Batch Update    ${SPREADSHEET_ID}    ${body}
+        """  # noqa: E501
+        return (
+            self.service.spreadsheets()
+            .batchUpdate(
+                spreadsheetId=spreadsheet_id,
+                body=body,
+            )
+            .execute()
+        )

--- a/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
+++ b/packages/google/src/RPA/Cloud/Google/keywords/sheets.py
@@ -230,7 +230,7 @@ class SheetsKeywords(LibraryContext):
             found_sheet = sheet_info["sheets"][0]
 
         sheet_title = found_sheet["title"]
-        target_column = self.to_A1_notation(found_sheet["columns"])
+        target_column = self.to_column_letter(found_sheet["columns"])
         rows = found_sheet["rows"]
         parameters["range"] = f"{sheet_title}!A1:{target_column}{rows}"
 
@@ -330,7 +330,7 @@ class SheetsKeywords(LibraryContext):
         return self.service.spreadsheets().get(spreadsheetId=sheet_id).execute()
 
     @keyword(tags=["sheets"])
-    def to_A1_notation(self, number: int):
+    def to_column_letter(self, number: int):
         """
         Convert a number into its Excel A1 notation character(s).
 


### PR DESCRIPTION
### WARNING

  **Breaking** changes in the ``Sheets`` keywords. All actions/properties
  related to a whole spreadsheet will use `spreadsheet` name and `sheet` will
  be used to indicate a single sheet in a spreadsheet. This is to be consistent
  with Google API naming.

### Add new keywords:

- `Copy spreadsheet` -  copy existing spreadsheet into another spreadsheet
- `Create spreadsheet` -  create a new spreadsheet
- `Delete sheet` -  delete existing sheet with a given spreadsheet id 
- `Generic spreadsheet batch update` - keyword used internally by the library which allows a lot of operations to be done with a given spreadsheet (see keyword documentation)
- `Get all sheet values` - returns all sheet values (the range is determined from sheet information) about a given spreadsheet id and sheet name (optional, default is the first sheet).
- `Get spreadsheet basic information` - returns a dictionary (title, id, url, sheets) about a given spreadsheet id.
- `Get spreadsheet details` - returns basic information plus for example sheet formatting information about a given spreadsheet id.
- `Rename sheet` - rename the existing sheet with a given spreadsheet id with a different name
- `To column letter` - converts the number (for a column) and converts it to a column letter,  for example 30 to column letter AD

### Repurposed keywords

- `Copy sheet`  (now will copy a sheet within a spreadsheet)
- `Create sheet` (now will create a sheet within a spreadsheet)