### PR TITLE
Make `core` use Robocorp webdriver sources and `truststore`

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -12,6 +12,22 @@ Latest versions
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+- Enables system certificate store usage with ``truststore`` automatic injection.
+  Minimum versions for this to happen are Python **3.10.12** and ``pip`` **23.2.1**.
+  (:issue:`1083`)
+- Library **RPA.Browser.Selenium** (:pr:`1084`; ``rpaframework-core`` **11.1.0**):
+
+  - Fixes webdriver caching when attempting previously downloaded executable reuse and
+    latest release version retrieval optimization.
+  - Use Robocorp controlled secure sources for querying and downloading webdrivers.
+    Base URL to whitelist (:issue:`1080`) -- set `RPA_EXTERNAL_WEBDRIVERS` to any value
+    if you want to default to the previously used external sources:
+    https://downloads.robocorp.com/ext/webdrivers/
+  - Ability to take into use a 64bit webdriver version for IE on a 64bit Windows system
+    by setting `RPA_ALLOW_64BIT_IE` to any value. (by default the 32bit version is used
+    as that's the recommendation provided by Selenium)
+
+
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -42,7 +58,6 @@ Latest versions
     related to a whole spreadsheet will use `spreadsheet` name and `sheet` will
     be used to indicate a single sheet in a spreadsheet. This is to be consistent
     with Google API naming.
-
 
 24 Aug 2023
 -----------

--- a/invocations/requirements.txt
+++ b/invocations/requirements.txt
@@ -1,5 +1,5 @@
 invoke~=1.7.1
-pip>=21.3
+pip>=23.2.1
 poetry~=1.4.0
 keyring~=23.9.0
 toml~=0.10.2

--- a/packages/core/poetry.lock
+++ b/packages/core/poetry.lock
@@ -913,14 +913,14 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-co
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
 
 [package.extras]
@@ -1059,14 +1059,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.4.0"
+version = "7.4.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
-    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+    {file = "pytest-7.4.1-py3-none-any.whl", hash = "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"},
+    {file = "pytest-7.4.1.tar.gz", hash = "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab"},
 ]
 
 [package.dependencies]
@@ -1252,14 +1252,14 @@ jeepney = ">=0.6"
 
 [[package]]
 name = "selenium"
-version = "4.11.2"
+version = "4.12.0"
 description = ""
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "selenium-4.11.2-py3-none-any.whl", hash = "sha256:98e72117b194b3fa9c69b48998f44bf7dd4152c7bd98544911a1753b9f03cc7d"},
-    {file = "selenium-4.11.2.tar.gz", hash = "sha256:9f9a5ed586280a3594f7461eb1d9dab3eac9d91e28572f365e9b98d9d03e02b5"},
+    {file = "selenium-4.12.0-py3-none-any.whl", hash = "sha256:b2c48b1440db54a0653300d9955f5421390723d53b36ec835e18de8e13bbd401"},
+    {file = "selenium-4.12.0.tar.gz", hash = "sha256:95be6aa449a0ab4ac1198bb9de71bbe9170405e04b9752f4b450dc7292a21828"},
 ]
 
 [package.dependencies]

--- a/packages/core/poetry.lock
+++ b/packages/core/poetry.lock
@@ -288,64 +288,64 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.3.0"
+version = "7.3.1"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db76a1bcb51f02b2007adacbed4c88b6dee75342c37b05d1822815eed19edee5"},
-    {file = "coverage-7.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c02cfa6c36144ab334d556989406837336c1d05215a9bdf44c0bc1d1ac1cb637"},
-    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:477c9430ad5d1b80b07f3c12f7120eef40bfbf849e9e7859e53b9c93b922d2af"},
-    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce2ee86ca75f9f96072295c5ebb4ef2a43cecf2870b0ca5e7a1cbdd929cf67e1"},
-    {file = "coverage-7.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68d8a0426b49c053013e631c0cdc09b952d857efa8f68121746b339912d27a12"},
-    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b3eb0c93e2ea6445b2173da48cb548364f8f65bf68f3d090404080d338e3a689"},
-    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:90b6e2f0f66750c5a1178ffa9370dec6c508a8ca5265c42fbad3ccac210a7977"},
-    {file = "coverage-7.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:96d7d761aea65b291a98c84e1250cd57b5b51726821a6f2f8df65db89363be51"},
-    {file = "coverage-7.3.0-cp310-cp310-win32.whl", hash = "sha256:63c5b8ecbc3b3d5eb3a9d873dec60afc0cd5ff9d9f1c75981d8c31cfe4df8527"},
-    {file = "coverage-7.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:97c44f4ee13bce914272589b6b41165bbb650e48fdb7bd5493a38bde8de730a1"},
-    {file = "coverage-7.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74c160285f2dfe0acf0f72d425f3e970b21b6de04157fc65adc9fd07ee44177f"},
-    {file = "coverage-7.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b543302a3707245d454fc49b8ecd2c2d5982b50eb63f3535244fd79a4be0c99d"},
-    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad0f87826c4ebd3ef484502e79b39614e9c03a5d1510cfb623f4a4a051edc6fd"},
-    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13c6cbbd5f31211d8fdb477f0f7b03438591bdd077054076eec362cf2207b4a7"},
-    {file = "coverage-7.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fac440c43e9b479d1241fe9d768645e7ccec3fb65dc3a5f6e90675e75c3f3e3a"},
-    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3c9834d5e3df9d2aba0275c9f67989c590e05732439b3318fa37a725dff51e74"},
-    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4c8e31cf29b60859876474034a83f59a14381af50cbe8a9dbaadbf70adc4b214"},
-    {file = "coverage-7.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7a9baf8e230f9621f8e1d00c580394a0aa328fdac0df2b3f8384387c44083c0f"},
-    {file = "coverage-7.3.0-cp311-cp311-win32.whl", hash = "sha256:ccc51713b5581e12f93ccb9c5e39e8b5d4b16776d584c0f5e9e4e63381356482"},
-    {file = "coverage-7.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:887665f00ea4e488501ba755a0e3c2cfd6278e846ada3185f42d391ef95e7e70"},
-    {file = "coverage-7.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d000a739f9feed900381605a12a61f7aaced6beae832719ae0d15058a1e81c1b"},
-    {file = "coverage-7.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59777652e245bb1e300e620ce2bef0d341945842e4eb888c23a7f1d9e143c446"},
-    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9737bc49a9255d78da085fa04f628a310c2332b187cd49b958b0e494c125071"},
-    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5247bab12f84a1d608213b96b8af0cbb30d090d705b6663ad794c2f2a5e5b9fe"},
-    {file = "coverage-7.3.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ac9a1de294773b9fa77447ab7e529cf4fe3910f6a0832816e5f3d538cfea9a"},
-    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:85b7335c22455ec12444cec0d600533a238d6439d8d709d545158c1208483873"},
-    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:36ce5d43a072a036f287029a55b5c6a0e9bd73db58961a273b6dc11a2c6eb9c2"},
-    {file = "coverage-7.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:211a4576e984f96d9fce61766ffaed0115d5dab1419e4f63d6992b480c2bd60b"},
-    {file = "coverage-7.3.0-cp312-cp312-win32.whl", hash = "sha256:56afbf41fa4a7b27f6635bc4289050ac3ab7951b8a821bca46f5b024500e6321"},
-    {file = "coverage-7.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f297e0c1ae55300ff688568b04ff26b01c13dfbf4c9d2b7d0cb688ac60df479"},
-    {file = "coverage-7.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac0dec90e7de0087d3d95fa0533e1d2d722dcc008bc7b60e1143402a04c117c1"},
-    {file = "coverage-7.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:438856d3f8f1e27f8e79b5410ae56650732a0dcfa94e756df88c7e2d24851fcd"},
-    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1084393c6bda8875c05e04fce5cfe1301a425f758eb012f010eab586f1f3905e"},
-    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49ab200acf891e3dde19e5aa4b0f35d12d8b4bd805dc0be8792270c71bd56c54"},
-    {file = "coverage-7.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67e6bbe756ed458646e1ef2b0778591ed4d1fcd4b146fc3ba2feb1a7afd4254"},
-    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8f39c49faf5344af36042b293ce05c0d9004270d811c7080610b3e713251c9b0"},
-    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7df91fb24c2edaabec4e0eee512ff3bc6ec20eb8dccac2e77001c1fe516c0c84"},
-    {file = "coverage-7.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:34f9f0763d5fa3035a315b69b428fe9c34d4fc2f615262d6be3d3bf3882fb985"},
-    {file = "coverage-7.3.0-cp38-cp38-win32.whl", hash = "sha256:bac329371d4c0d456e8d5f38a9b0816b446581b5f278474e416ea0c68c47dcd9"},
-    {file = "coverage-7.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b859128a093f135b556b4765658d5d2e758e1fae3e7cc2f8c10f26fe7005e543"},
-    {file = "coverage-7.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed8d310afe013db1eedd37176d0839dc66c96bcfcce8f6607a73ffea2d6ba"},
-    {file = "coverage-7.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61260ec93f99f2c2d93d264b564ba912bec502f679793c56f678ba5251f0393"},
-    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97af9554a799bd7c58c0179cc8dbf14aa7ab50e1fd5fa73f90b9b7215874ba28"},
-    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3558e5b574d62f9c46b76120a5c7c16c4612dc2644c3d48a9f4064a705eaee95"},
-    {file = "coverage-7.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37d5576d35fcb765fca05654f66aa71e2808d4237d026e64ac8b397ffa66a56a"},
-    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:07ea61bcb179f8f05ffd804d2732b09d23a1238642bf7e51dad62082b5019b34"},
-    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:80501d1b2270d7e8daf1b64b895745c3e234289e00d5f0e30923e706f110334e"},
-    {file = "coverage-7.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4eddd3153d02204f22aef0825409091a91bf2a20bce06fe0f638f5c19a85de54"},
-    {file = "coverage-7.3.0-cp39-cp39-win32.whl", hash = "sha256:2d22172f938455c156e9af2612650f26cceea47dc86ca048fa4e0b2d21646ad3"},
-    {file = "coverage-7.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:60f64e2007c9144375dd0f480a54d6070f00bb1a28f65c408370544091c9bc9e"},
-    {file = "coverage-7.3.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:5492a6ce3bdb15c6ad66cb68a0244854d9917478877a25671d70378bdc8562d0"},
-    {file = "coverage-7.3.0.tar.gz", hash = "sha256:49dbb19cdcafc130f597d9e04a29d0a032ceedf729e41b181f51cd170e6ee865"},
+    {file = "coverage-7.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd0f7429ecfd1ff597389907045ff209c8fdb5b013d38cfa7c60728cb484b6e3"},
+    {file = "coverage-7.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:966f10df9b2b2115da87f50f6a248e313c72a668248be1b9060ce935c871f276"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0575c37e207bb9b98b6cf72fdaaa18ac909fb3d153083400c2d48e2e6d28bd8e"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:245c5a99254e83875c7fed8b8b2536f040997a9b76ac4c1da5bff398c06e860f"},
+    {file = "coverage-7.3.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c96dd7798d83b960afc6c1feb9e5af537fc4908852ef025600374ff1a017392"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:de30c1aa80f30af0f6b2058a91505ea6e36d6535d437520067f525f7df123887"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:50dd1e2dd13dbbd856ffef69196781edff26c800a74f070d3b3e3389cab2600d"},
+    {file = "coverage-7.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9c0c19f70d30219113b18fe07e372b244fb2a773d4afde29d5a2f7930765136"},
+    {file = "coverage-7.3.1-cp310-cp310-win32.whl", hash = "sha256:770f143980cc16eb601ccfd571846e89a5fe4c03b4193f2e485268f224ab602f"},
+    {file = "coverage-7.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:cdd088c00c39a27cfa5329349cc763a48761fdc785879220d54eb785c8a38520"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:74bb470399dc1989b535cb41f5ca7ab2af561e40def22d7e188e0a445e7639e3"},
+    {file = "coverage-7.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:025ded371f1ca280c035d91b43252adbb04d2aea4c7105252d3cbc227f03b375"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6191b3a6ad3e09b6cfd75b45c6aeeffe7e3b0ad46b268345d159b8df8d835f9"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7eb0b188f30e41ddd659a529e385470aa6782f3b412f860ce22b2491c89b8593"},
+    {file = "coverage-7.3.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c8f0df9dfd8ff745bccff75867d63ef336e57cc22b2908ee725cc552689ec8"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7eb3cd48d54b9bd0e73026dedce44773214064be93611deab0b6a43158c3d5a0"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ac3c5b7e75acac31e490b7851595212ed951889918d398b7afa12736c85e13ce"},
+    {file = "coverage-7.3.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5b4ee7080878077af0afa7238df1b967f00dc10763f6e1b66f5cced4abebb0a3"},
+    {file = "coverage-7.3.1-cp311-cp311-win32.whl", hash = "sha256:229c0dd2ccf956bf5aeede7e3131ca48b65beacde2029f0361b54bf93d36f45a"},
+    {file = "coverage-7.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6f55d38818ca9596dc9019eae19a47410d5322408140d9a0076001a3dcb938c"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5289490dd1c3bb86de4730a92261ae66ea8d44b79ed3cc26464f4c2cde581fbc"},
+    {file = "coverage-7.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ca833941ec701fda15414be400c3259479bfde7ae6d806b69e63b3dc423b1832"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd694e19c031733e446c8024dedd12a00cda87e1c10bd7b8539a87963685e969"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aab8e9464c00da5cb9c536150b7fbcd8850d376d1151741dd0d16dfe1ba4fd26"},
+    {file = "coverage-7.3.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87d38444efffd5b056fcc026c1e8d862191881143c3aa80bb11fcf9dca9ae204"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8a07b692129b8a14ad7a37941a3029c291254feb7a4237f245cfae2de78de037"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:2829c65c8faaf55b868ed7af3c7477b76b1c6ebeee99a28f59a2cb5907a45760"},
+    {file = "coverage-7.3.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f111a7d85658ea52ffad7084088277135ec5f368457275fc57f11cebb15607f"},
+    {file = "coverage-7.3.1-cp312-cp312-win32.whl", hash = "sha256:c397c70cd20f6df7d2a52283857af622d5f23300c4ca8e5bd8c7a543825baa5a"},
+    {file = "coverage-7.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:5ae4c6da8b3d123500f9525b50bf0168023313963e0e2e814badf9000dd6ef92"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ca70466ca3a17460e8fc9cea7123c8cbef5ada4be3140a1ef8f7b63f2f37108f"},
+    {file = "coverage-7.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f2781fd3cabc28278dc982a352f50c81c09a1a500cc2086dc4249853ea96b981"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6407424621f40205bbe6325686417e5e552f6b2dba3535dd1f90afc88a61d465"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04312b036580ec505f2b77cbbdfb15137d5efdfade09156961f5277149f5e344"},
+    {file = "coverage-7.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac9ad38204887349853d7c313f53a7b1c210ce138c73859e925bc4e5d8fc18e7"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:53669b79f3d599da95a0afbef039ac0fadbb236532feb042c534fbb81b1a4e40"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:614f1f98b84eb256e4f35e726bfe5ca82349f8dfa576faabf8a49ca09e630086"},
+    {file = "coverage-7.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f1a317fdf5c122ad642db8a97964733ab7c3cf6009e1a8ae8821089993f175ff"},
+    {file = "coverage-7.3.1-cp38-cp38-win32.whl", hash = "sha256:defbbb51121189722420a208957e26e49809feafca6afeef325df66c39c4fdb3"},
+    {file = "coverage-7.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:f4f456590eefb6e1b3c9ea6328c1e9fa0f1006e7481179d749b3376fc793478e"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f12d8b11a54f32688b165fd1a788c408f927b0960984b899be7e4c190ae758f1"},
+    {file = "coverage-7.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f09195dda68d94a53123883de75bb97b0e35f5f6f9f3aa5bf6e496da718f0cb6"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6601a60318f9c3945be6ea0f2a80571f4299b6801716f8a6e4846892737ebe4"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07d156269718670d00a3b06db2288b48527fc5f36859425ff7cec07c6b367745"},
+    {file = "coverage-7.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:636a8ac0b044cfeccae76a36f3b18264edcc810a76a49884b96dd744613ec0b7"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5d991e13ad2ed3aced177f524e4d670f304c8233edad3210e02c465351f785a0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:586649ada7cf139445da386ab6f8ef00e6172f11a939fc3b2b7e7c9082052fa0"},
+    {file = "coverage-7.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4aba512a15a3e1e4fdbfed2f5392ec221434a614cc68100ca99dcad7af29f3f8"},
+    {file = "coverage-7.3.1-cp39-cp39-win32.whl", hash = "sha256:6bc6f3f4692d806831c136c5acad5ccedd0262aa44c087c46b7101c77e139140"},
+    {file = "coverage-7.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:553d7094cb27db58ea91332e8b5681bac107e7242c23f7629ab1316ee73c4981"},
+    {file = "coverage-7.3.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:220eb51f5fb38dfdb7e5d54284ca4d0cd70ddac047d750111a68ab1798945194"},
+    {file = "coverage-7.3.1.tar.gz", hash = "sha256:6cb7fe1581deb67b782c153136541e20901aa312ceedaf1467dcb35255787952"},
 ]
 
 [package.dependencies]
@@ -1270,20 +1270,20 @@ urllib3 = {version = ">=1.26,<3", extras = ["socks"]}
 
 [[package]]
 name = "setuptools"
-version = "68.1.2"
+version = "68.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.1.2-py3-none-any.whl", hash = "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"},
-    {file = "setuptools-68.1.2.tar.gz", hash = "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"},
+    {file = "setuptools-68.2.0-py3-none-any.whl", hash = "sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8"},
+    {file = "setuptools-68.2.0.tar.gz", hash = "sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5,<=7.1.2)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "sniffio"
@@ -1368,14 +1368,14 @@ sortedcontainers = "*"
 
 [[package]]
 name = "trio-websocket"
-version = "0.10.3"
+version = "0.10.4"
 description = "WebSocket library for Trio"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "trio-websocket-0.10.3.tar.gz", hash = "sha256:1a748604ad906a7dcab9a43c6eb5681e37de4793ba0847ef0bc9486933ed027b"},
-    {file = "trio_websocket-0.10.3-py3-none-any.whl", hash = "sha256:a9937d48e8132ebf833019efde2a52ca82d223a30a7ea3e8d60a7d28f75a4e3a"},
+    {file = "trio-websocket-0.10.4.tar.gz", hash = "sha256:e66b3db3e2453017431dfbd352081006654e1241c2a6800dc2f43d7df54d55c5"},
+    {file = "trio_websocket-0.10.4-py3-none-any.whl", hash = "sha256:c7a620c4013c34b7e4477d89fe76695da1e455e4510a8d7ae13f81c632bdce1d"},
 ]
 
 [package.dependencies]

--- a/packages/core/poetry.lock
+++ b/packages/core/poetry.lock
@@ -1384,6 +1384,18 @@ trio = ">=0.11"
 wsproto = ">=0.14"
 
 [[package]]
+name = "truststore"
+version = "0.7.0"
+description = "Verify certificates using native system trust stores"
+category = "main"
+optional = false
+python-versions = ">= 3.10"
+files = [
+    {file = "truststore-0.7.0-py3-none-any.whl", hash = "sha256:a4b410a365cafec4c2b386b30df53d89a6a4466cc229c7026e41c2d847f94fe9"},
+    {file = "truststore-0.7.0.tar.gz", hash = "sha256:72e784507a624375434381e4bad3eff8614bc8c845a7f5ae16a25a2624d0683f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1542,4 +1554,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c902d29ff034e5aa16436cd6c11eea48e7043e74e3bddfc11617dd4c6c576ba7"
+content-hash = "2ea20303075220e77df931843e45f19c7515c839b52cb2f7fc1aa9703cf663c6"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -32,10 +32,11 @@ python = "^3.8"
 selenium = "^4.6.1"
 webdriver-manager = "4.0.0"
 psutil = { version = "^5.9.0", platform = "win32" }
-pywin32 = { version = ">=300,<304", platform = "win32", python = "!=3.8.1,!=3.7.6" }
+pywin32 = { version = ">=300,<304", platform = "win32", python = "!=3.8.1" }
 uiautomation = { version = "^2.0.15", platform = "win32" }
 pillow = "^9.1.1"
-packaging = ">=21.3,<24"
+packaging = "^23.1"
+truststore = { version = "^0.7.0", python = ">=3.10.12" }
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.3.0"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-core"
-version = "11.0.6"
+version = "11.1.0"
 description = "Core utilities used by RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/core/src/RPA/core/__init__.py
+++ b/packages/core/src/RPA/core/__init__.py
@@ -1,0 +1,4 @@
+from .certificates import use_system_certificates
+
+
+use_system_certificates()

--- a/packages/core/src/RPA/core/certificates.py
+++ b/packages/core/src/RPA/core/certificates.py
@@ -37,7 +37,9 @@ def use_system_certificates():
     Call this before importing anything else.
     """
     # Works with Python 3.10.12, pip 23.2.1 and above.
-    if sys.version_info >= (3, 10, 12) and _check_pip_version("23.2.1"):
+    py_version = (3, 10, 12)
+    pip_version_str = "23.2.1"
+    if sys.version_info >= py_version and _check_pip_version(pip_version_str):
         import truststore  # pylint: disable=import-outside-toplevel
 
         truststore.inject_into_ssl()
@@ -48,5 +50,7 @@ def use_system_certificates():
     else:
         logging.info(
             "Truststore not in use, HTTPS traffic validated against `certifi` package."
-            " (requires Python 3.10.12 and 'pip' 23.2.1 at minimum)"
+            " (requires Python %s and 'pip' %s at minimum)",
+            ".".join(str(nr) for nr in py_version),
+            pip_version_str
         )

--- a/packages/core/src/RPA/core/certificates.py
+++ b/packages/core/src/RPA/core/certificates.py
@@ -43,16 +43,16 @@ def use_system_certificates():
         try:
             import truststore  # pylint: disable=import-outside-toplevel
         except ImportError:
-            LOGGER.debug("Dependency `truststore` is not installed.")
+            LOGGER.debug("Dependency `truststore` is not installed!")
         else:
             truststore.inject_into_ssl()
-            logging.info(
+            LOGGER.info(
                 "Truststore injection done, using system certificate store to validate"
                 " HTTPS."
             )
             return
 
-    logging.info(
+    LOGGER.info(
         "Truststore not in use, HTTPS traffic validated against `certifi` package."
         " (requires Python %s and 'pip' %s at minimum)",
         ".".join(str(nr) for nr in py_version),

--- a/packages/core/src/RPA/core/certificates.py
+++ b/packages/core/src/RPA/core/certificates.py
@@ -40,17 +40,21 @@ def use_system_certificates():
     py_version = (3, 10, 12)
     pip_version_str = "23.2.1"
     if sys.version_info >= py_version and _check_pip_version(pip_version_str):
-        import truststore  # pylint: disable=import-outside-toplevel
+        try:
+            import truststore  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            LOGGER.debug("Dependency `truststore` is not installed.")
+        else:
+            truststore.inject_into_ssl()
+            logging.info(
+                "Truststore injection done, using system certificate store to validate"
+                " HTTPS."
+            )
+            return
 
-        truststore.inject_into_ssl()
-        logging.info(
-            "Truststore injection done, using system certificate store to validate"
-            " HTTPS."
-        )
-    else:
-        logging.info(
-            "Truststore not in use, HTTPS traffic validated against `certifi` package."
-            " (requires Python %s and 'pip' %s at minimum)",
-            ".".join(str(nr) for nr in py_version),
-            pip_version_str,
-        )
+    logging.info(
+        "Truststore not in use, HTTPS traffic validated against `certifi` package."
+        " (requires Python %s and 'pip' %s at minimum)",
+        ".".join(str(nr) for nr in py_version),
+        pip_version_str,
+    )

--- a/packages/core/src/RPA/core/certificates.py
+++ b/packages/core/src/RPA/core/certificates.py
@@ -52,5 +52,5 @@ def use_system_certificates():
             "Truststore not in use, HTTPS traffic validated against `certifi` package."
             " (requires Python %s and 'pip' %s at minimum)",
             ".".join(str(nr) for nr in py_version),
-            pip_version_str
+            pip_version_str,
         )

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -265,11 +265,23 @@ _DRIVER_SOURCES = {
         "latest_release_url": _join_base("chrome/v1/LATEST_RELEASE"),
         "versions_url": _join_base("chrome/v2/known-good-versions-with-downloads.json"),
     },
+    "firefox": {
+        "url": _join_base("firefox/download"),
+        "latest_release_url": _join_base("firefox/releases/latest"),
+        "mozila_release_tag": _join_base("firefox/releases/tags/{0}"),
+    },
     "edge": {
         "url": _join_base("edge"),
         "latest_release_url": _join_base("edge/LATEST_RELEASE"),
     },
+    "ie": {
+        "url": _join_base("ie/download"),
+        "latest_release_url": _join_base("ie/releases"),
+        "ie_release_tag": _join_base("ie/releases/tags/selenium-{0}"),
+    },
 }
+_DRIVER_SOURCES["gecko"] = _DRIVER_SOURCES["mozilla"] = _DRIVER_SOURCES["firefox"]
+_DRIVER_SOURCES["chromiumedge"] = _DRIVER_SOURCES["edge"]
 # Available `WebDriver` classes in Selenium.
 SUPPORTED_BROWSERS = dict(
     {name: name.capitalize() for name in AVAILABLE_DRIVERS},

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -39,10 +39,12 @@ class DriverCacheManager(_DriverCacheManager):
     # pylint: disable=unused-private-member
     def __get_metadata_key(self, *args, **kwargs) -> str:
         # pylint: disable=super-with-arguments
-        call = lambda: super(  # noqa: E731
-            DriverCacheManager, self
-        )._DriverCacheManager__get_metadata_key(*args, **kwargs)
-        return call() or call()
+        get_metadata_key = functools.partial(
+            super(DriverCacheManager, self)._DriverCacheManager__get_metadata_key,
+            *args,
+            **kwargs,
+        )
+        return get_metadata_key() or get_metadata_key()
 
 
 class ChromeDriver(_ChromeDriver):
@@ -360,9 +362,8 @@ def _to_manager(browser: str, *, root: Path) -> DriverManager:
     cache_manager = DriverCacheManager(root_dir=str(root))
     manager = manager_factory(cache_manager=cache_manager)
     driver = manager.driver
-    driver.get_latest_release_version = functools.cache(
-        driver.get_latest_release_version
-    )
+    cache = getattr(functools, "cache", functools.lru_cache(maxsize=None))
+    driver.get_latest_release_version = cache(driver.get_latest_release_version)
     return manager
 
 

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -230,14 +230,14 @@ AVAILABLE_DRIVERS = {
 #  can opt out from using our own trusted internal source and default to
 #  `webdriver-manager`'s implicit locations.
 _USE_EXTERNAL_WEBDRIVERS = bool(os.getenv("RPA_EXTERNAL_WEBDRIVERS"))
-_SOURCE_BASE = os.getenv("RC_WEBDRIVER_SOURCE", "https://dependencies.robocorp.com")
+_SOURCE_BASE = os.getenv("RC_WEBDRIVER_SOURCE", "https://downloads.robocorp.com/ext/webdrivers/")
 _join_base = functools.partial(urljoin, _SOURCE_BASE)
 _DRIVER_SOURCES = {
     "chrome": {
-        "url": _join_base("/webdrivers/chrome/v1"),
-        "latest_release_url": _join_base("/webdrivers/chrome/v1/LATEST_RELEASE"),
+        "url": _join_base("chrome/v1"),
+        "latest_release_url": _join_base("chrome/v1/LATEST_RELEASE"),
         "versions_url": _join_base(
-            "/webdrivers/chrome/v2/known-good-versions-with-downloads.json"
+            "chrome/v2/known-good-versions-with-downloads.json"
         ),
     },
 }

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -282,7 +282,8 @@ _DRIVER_SOURCES = {
 }
 _DRIVER_SOURCES["gecko"] = _DRIVER_SOURCES["mozilla"] = _DRIVER_SOURCES["firefox"]
 _DRIVER_SOURCES["chromiumedge"] = _DRIVER_SOURCES["edge"]
-# Available `WebDriver` classes in Selenium.
+# Available `WebDriver` classes in Selenium which also support automatic webdriver
+#  download with `webdriver-manager`.
 SUPPORTED_BROWSERS = dict(
     {name: name.capitalize() for name in AVAILABLE_DRIVERS},
     **{"chromiumedge": "ChromiumEdge"},

--- a/packages/core/tests/python/test_webdriver.py
+++ b/packages/core/tests/python/test_webdriver.py
@@ -1,24 +1,40 @@
 import unittest.mock as mock
 
 import pytest
+from webdriver_manager.core.os_manager import ChromeType
 
 from RPA.core import webdriver
 
 from . import RESULTS_DIR
 
 
+@pytest.fixture(autouse=True, scope="module")
+def disable_caching():
+    with mock.patch(
+        "webdriver_manager.core.driver_cache.DriverCacheManager.find_driver",
+        new=mock.Mock(return_value=None),
+    ):
+        yield
+
+
+# Tests with different Chrome versions, which trigger different download approaches.
 @pytest.mark.parametrize("version_override", [None, "114.0.5735.198", "115.0.5790.110"])
-# Disables caching.
-@mock.patch(
-    "webdriver_manager.core.driver_cache.DriverCacheManager.find_driver",
-    new=mock.Mock(return_value=None),
-)
 def test_chrome_download(version_override):
-    driver_target = "RPA.core.webdriver.ChromeDriver"
-    with mock.patch(driver_target, wraps=webdriver.ChromeDriver) as MockChromeDriver:
+    get_version_target = "RPA.core.webdriver.ChromeDriver.get_browser_version_from_os"
+    browser_type = (
+        ChromeType.CHROMIUM if webdriver._is_chromium() else ChromeType.GOOGLE
+    )
+    get_version = lambda: webdriver._OPS_MANAGER.get_browser_version_from_os(
+        browser_type
+    )
+    with mock.patch(get_version_target, wraps=get_version) as mock_get_version:
         if version_override:
-            mock_get_version = mock.Mock(return_value=version_override)
-            MockChromeDriver.get_browser_version_from_os = mock_get_version
+            mock_get_version.return_value = version_override
 
         path = webdriver.download("Chrome", root=RESULTS_DIR)
         assert "chromedriver" in path
+
+
+def test_edge_download():
+    path = webdriver.download("Edge", root=RESULTS_DIR)
+    assert "msedgedriver" in path

--- a/packages/core/tests/python/test_webdriver.py
+++ b/packages/core/tests/python/test_webdriver.py
@@ -35,6 +35,16 @@ def test_chrome_download(version_override):
         assert "chromedriver" in path
 
 
+def test_firefox_download():
+    path = webdriver.download("Firefox", root=RESULTS_DIR)
+    assert "geckodriver" in path
+
+
 def test_edge_download():
     path = webdriver.download("Edge", root=RESULTS_DIR)
     assert "msedgedriver" in path
+
+
+def test_ie_download():
+    path = webdriver.download("Ie", root=RESULTS_DIR)
+    assert "IEDriverServer.exe" in path

--- a/packages/core/tests/python/test_webdriver.py
+++ b/packages/core/tests/python/test_webdriver.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import pytest
 
 from RPA.core import webdriver
@@ -6,22 +7,18 @@ from RPA.core import webdriver
 from . import RESULTS_DIR
 
 
-def _test_chrome_download():
-    path = webdriver.download("Chrome", root=RESULTS_DIR)
-    assert "chromedriver" in path
-
-
 @pytest.mark.parametrize("version_override", [None, "114.0.5735.198", "115.0.5790.110"])
+# Disables caching.
 @mock.patch(
     "webdriver_manager.core.driver_cache.DriverCacheManager.find_driver",
     new=mock.Mock(return_value=None),
-)  # disable caching
+)
 def test_chrome_download(version_override):
-    if not version_override:
-        _test_chrome_download()
-        return
+    driver_target = "RPA.core.webdriver.ChromeDriver"
+    with mock.patch(driver_target, wraps=webdriver.ChromeDriver) as MockChromeDriver:
+        if version_override:
+            mock_get_version = mock.Mock(return_value=version_override)
+            MockChromeDriver.get_browser_version_from_os = mock_get_version
 
-    get_version_location = "RPA.core.webdriver.ChromeDriver.get_browser_version_from_os"
-    with mock.patch(get_version_location) as get_version:
-        get_version.return_value = version_override
-        _test_chrome_download()
+        path = webdriver.download("Chrome", root=RESULTS_DIR)
+        assert "chromedriver" in path


### PR DESCRIPTION
Closes #1080 
[Source](https://github.com/robocorp/robocorp-infra/pull/279#pullrequestreview-1609592974) for our own URLs

Closes #1083 

### ToDo
- [x] Adapt the same mechanism for the rest: Firefox, Edge, IE.
- [x] Ensure through testing that the base of the requested URLs belongs to us.