### PR TITLE
`RPA.Cloud.Google`. Add possibility to send HTML email

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -16,6 +16,13 @@ Latest versions
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+14 Sep 2023
+-----------
+
+- Library **RPA.Cloud.Google** (:pr:`1092`; ``rpaframework-google`` **8.1.0**): Add
+  possibility to send HTML email by adding `html` parameter for ``Send Message``
+  keyword.
+
 27.0.1 - 11 Sep 2023
 --------------------
 

--- a/packages/google/pyproject.toml
+++ b/packages/google/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework-google"
-version = "8.0.0"
+version = "8.1.0"
 description = "Google library for RPA Framework"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"

--- a/packages/google/src/RPA/Cloud/Google/keywords/gmail.py
+++ b/packages/google/src/RPA/Cloud/Google/keywords/gmail.py
@@ -85,6 +85,7 @@ class GmailKeywords(LibraryContext):
         subject: str,
         message_text: str,
         attachments: list = None,
+        html: bool = False,
     ):
         """Create a message for an email.
 
@@ -92,12 +93,17 @@ class GmailKeywords(LibraryContext):
         :param subject: message subject
         :param message_text: message body text
         :param attachment: list of files to add as message attachments
+        :param html: set to True if message body is HTML (default False, plain text)
         :return: An object containing a base64url encoded email object
         """
         mimeMessage = MIMEMultipart()
         mimeMessage["to"] = to
         mimeMessage["subject"] = subject
-        mimeMessage.attach(MIMEText(message_text, "plain"))
+
+        if html:
+            mimeMessage.attach(MIMEText(message_text, "html"))
+        else:
+            mimeMessage.attach(MIMEText(message_text, "plain"))
 
         for at in attachments:
             self.add_attachment_to_message(mimeMessage, at)
@@ -135,6 +141,7 @@ class GmailKeywords(LibraryContext):
         subject: str,
         message_text: str,
         attachments: list = None,
+        html: bool = False,
     ):
         """Send an email message.
 
@@ -143,6 +150,7 @@ class GmailKeywords(LibraryContext):
         :param subject: message subject
         :param message_text: message body text
         :param attachment: list of files to add as message attachments
+        :param html: set to True if message body is HTML (default False, plain text)
         :return: sent message
 
         Example:
@@ -161,7 +169,7 @@ class GmailKeywords(LibraryContext):
         if not self.service:
             raise AssertionError("Gmail service has not been initialized")
         attachments = attachments or []
-        message = self.create_message(to, subject, message_text, attachments)
+        message = self.create_message(to, subject, message_text, attachments, html)
         try:
             response = (
                 self.service.users()


### PR DESCRIPTION
Add `html` parameter for the `Send Message` keyword which will be by default `False`. This will preserve the original keyword behaviour which sends messages as plain text.