### PR TITLE
Clarify restrictions on parent/child syntax of Get Elements

### DIFF
--- a/packages/windows/src/RPA/Windows/keywords/locators.py
+++ b/packages/windows/src/RPA/Windows/keywords/locators.py
@@ -176,6 +176,13 @@ class LocatorKeywords(LocatorMethods):
         By default, only the siblings (similar elements on the same level) are taken
         into account. In order to search globally, turn `siblings_only` off, but be
         aware that this will take more time to process.
+
+        Note that if the syntax ``parent_locator > child_locator`` is used
+        in the locator, it is assumed that ``parent_locator`` returns a
+        singular element - i.e. if the locator ``parent_locator`` returns multiple
+        elements, only the first result is used for further processing, even if
+        `siblings_only` is off.
+
         For more details on the rest of parameters, take a look at the ``Get Element``
         keyword.
 


### PR DESCRIPTION
What I would have expected from Windows.Get Elements is that if I provide a locator of the form 

``locator_returning_multiple_elements > locator_returning_multiple_children``, then the return is the union of all applicable children of *all* elements targeted by ``locator_returning_multiple_elements``, similarly to how XPath would process ``locator_returning_multiple_elements[*]``. However, this is not the case - only the first result of ``locator_returning_multiple_elements`` is processed.

This documentation change aims to clarify that. 

(Ideally, that behavior would be changed, but I assume that would be a breaking change...)