### PR TITLE
`RPA.Outlook.Application` update/fix `Move Emails` keyword

### DIFF
--- a/packages/main/poetry.lock
+++ b/packages/main/poetry.lock
@@ -1069,13 +1069,13 @@ testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packag
 
 [[package]]
 name = "importlib-resources"
-version = "6.1.0"
+version = "6.1.1"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.1.0-py3-none-any.whl", hash = "sha256:aa50258bbfa56d4e33fbd8aa3ef48ded10d1735f11532b8df95388cc6bdb7e83"},
-    {file = "importlib_resources-6.1.0.tar.gz", hash = "sha256:9d48dcccc213325e810fd723e7fbb45ccb39f6cf5c31f00cf2b965f5f10f3cb9"},
+    {file = "importlib_resources-6.1.1-py3-none-any.whl", hash = "sha256:e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"},
+    {file = "importlib_resources-6.1.1.tar.gz", hash = "sha256:3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"},
 ]
 
 [package.dependencies]
@@ -1338,8 +1338,6 @@ files = [
     {file = "lxml-4.9.3-cp27-cp27m-macosx_11_0_x86_64.whl", hash = "sha256:b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c"},
     {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d"},
     {file = "lxml-4.9.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef"},
-    {file = "lxml-4.9.3-cp27-cp27m-win32.whl", hash = "sha256:2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7"},
-    {file = "lxml-4.9.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1"},
     {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb"},
     {file = "lxml-4.9.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e"},
     {file = "lxml-4.9.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991"},
@@ -3417,13 +3415,13 @@ wsproto = ">=0.14"
 
 [[package]]
 name = "trove-classifiers"
-version = "2023.10.18"
+version = "2023.11.9"
 description = "Canonical source for classifiers on PyPI (pypi.org)."
 optional = false
 python-versions = "*"
 files = [
-    {file = "trove-classifiers-2023.10.18.tar.gz", hash = "sha256:2cdfcc7f31f7ffdd57666a9957296089ac72daad4d11ab5005060e5cd7e29939"},
-    {file = "trove_classifiers-2023.10.18-py3-none-any.whl", hash = "sha256:20a3da8e3cb65587cc9f5d5b837bf74edeb480bba9bd8cd4f03ab056d6b06c4c"},
+    {file = "trove-classifiers-2023.11.9.tar.gz", hash = "sha256:0542bc03d151f8af84f0eb0e74aa931b374b6f9c8ed8fbf7ee41989fb9d40f1d"},
+    {file = "trove_classifiers-2023.11.9-py3-none-any.whl", hash = "sha256:f9784ab55054bb327d0c8d33931fb2555b81e5b4868832490ab7959ae3ea9186"},
 ]
 
 [[package]]

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -415,7 +415,7 @@ class Application(BaseApplication):
         source_folder: str = None,
         email_filter: Any = None,
         target_folder: str = None,
-        mark_as_read: bool = False,
+        mark_as_read: bool = True,
     ) -> bool:
         """Move emails from source folder to target folder.
 
@@ -427,6 +427,7 @@ class Application(BaseApplication):
         :param email_filter: how to filter email, default no filter,
          ie. all emails in folder
         :param target_folder: folder where emails are moved into
+        :param mark_as_read: mark emails as read after move, defaults to True
         :return: True if move operation was success, False if not
 
         Python example.

--- a/packages/main/src/RPA/Outlook/Application.py
+++ b/packages/main/src/RPA/Outlook/Application.py
@@ -413,8 +413,9 @@ class Application(BaseApplication):
         self,
         account_name: str = None,
         source_folder: str = None,
-        email_filter: str = None,
+        email_filter: Any = None,
         target_folder: str = None,
+        mark_as_read: bool = False,
     ) -> bool:
         """Move emails from source folder to target folder.
 
@@ -428,7 +429,33 @@ class Application(BaseApplication):
         :param target_folder: folder where emails are moved into
         :return: True if move operation was success, False if not
 
-        Example:
+        Python example.
+
+        .. code-block:: python
+
+            outlook = RPA.Outlook.Application()
+
+            # moving messages from Inbox to target_folder
+            outlook.move_emails(
+                target_folder='Processed Invoices',
+                email_filter="[Subject]='incoming invoice'"
+            )
+
+            # moving messages from source_folder to target_folder
+            outlook.move_emails(
+                source_folder='Incoming Invoices',
+                target_folder='Processed Invoices',
+                email_filter="[Subject]='incoming invoice'"
+            )
+
+            # move message objects from `get_emails` result
+            emails = outlook.get_emails("[Subject]='incoming invoice'")
+            outlook.move_emails(
+                target_folder='Processed Invoices',
+                email_filter=emails
+            )
+
+        Robot Framework example.
 
         .. code-block:: robotframework
 
@@ -442,31 +469,41 @@ class Application(BaseApplication):
             ...    source_folder=Incoming Invoices
             ...    target_folder=Processed Invoices
             ...    email_filter=[Subject]='incoming invoice'
+
+            # moving message objects from `Get Emails` result
+            ${emails}=    Get Emails    [Subject]='incoming invoice'
+            Move Emails
+            ...    target_folder=Processed Invoices
+            ...    email_filter=${emails}
         """
         if not target_folder:
             raise AttributeError("Can't move emails without target_folder")
-        folder = self._get_folder(account_name, source_folder)
-        folder_messages = folder.Items if folder else []
-        if folder_messages and email_filter:
+        tf = self._get_folder(account_name, target_folder)
+        if not tf or tf.Name != target_folder:
+            raise AttributeError("Did not find target folder")
+        self.logger.info("Found target folder: %s", tf.Name)
+        if email_filter and not isinstance(email_filter, str):
+            folder_messages = (
+                email_filter if isinstance(email_filter, list) else [email_filter]
+            )
+        else:
+            folder = self._get_folder(account_name, source_folder)
+            folder_messages = folder.Items if folder else []
             try:
                 folder_messages = folder_messages.Restrict(email_filter)
             except Exception:  # pylint: disable=broad-except
                 raise AttributeError(  # pylint: disable=raise-missing-from
                     "Invalid email filter '%s'" % email_filter
                 )
-        if not folder_messages:
+        if not folder_messages or len(folder_messages) == 0:
             self.logger.warning("Did not find emails to move")
             return False
-        tf = self._get_folder(account_name, target_folder)
-        if not tf or tf.Name != target_folder:
-            self.logger.warning("Did not find target folder")
-            return False
         self.logger.info("Found %d emails to move", len(folder_messages))
-        self.logger.info("Found target folder: %s", tf.Name)
         for m in folder_messages:
-            m.UnRead = False
+            m = m["object"] if isinstance(m, dict) else m
+            if mark_as_read:
+                m.UnRead = False
             m.Move(tf)
-            m.Save()
         return True
 
     def _mail_item_to_dict(self, mail_item):


### PR DESCRIPTION
Parameter `email_filter`'s type has been changed so that it can be given 
1. a string email filter (existing functionality)
2. single email (of type MailItem or dictionary representing email)
3. list of MailItems/dictionaries.

Also added parameter `mark_as_read` which when set True will mark all emails which has been moved as Read (default). 

usage example after this PR has been released
```robotframework
*** Tasks ***
All and filter
    Open Application
    ${emails}=    Get Emails
    @{move_these}=    Create List
    FOR    ${email}    IN    @{emails}
        Log To Console    SUBJECT: ${email}[Subject]
        IF    "Azure" in "${email}[Subject]"
            Log To Console    ... TO BE MOVED
            Append to List    ${move_these}    ${email}
        END
    END
    Log To Console    ... Moving ${{len($move_these)}} emails
    # Pass list of email dictionaries to move
    Move Emails    email_filter=${move_these}    target_folder=Azure    mark_as_read=True
    Log    Done.

Filter and move
    Open Application
    ${emails}=    Get Emails    email_filter=[Subject]='Azure AD Identity Protection Weekly Digest'
    IF    len($emails) > 0
         # Pass list of email dictionaries to move
        Move Emails    email_filter=${emails}    target_folder=Azure
    END

Move with filter
    Open Application
    # Pass email filter string (existing functionality)
    Move Emails    email_filter=[Subject]='Azure AD Identity Protection Weekly Digest'    target_folder=Azure
```