### PR TITLE
`RPA.Crypto` Return generated key and decoded string as 'str' type when using AES256

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -20,6 +20,8 @@ Latest versions
 
 - Library **RPA.Browser.Selenium** (:pr:`1139`): Keyword ``Open Available Browser`` won't
   anymore try to initialize webdrivers for browsers that are not installed in the system.
+- Library **RPA.Crypto** (:pr:`1140`): Fix `AES256`` return types for keywords
+  ``Generate Key`` and ``Decrypt String``.
 - Library **RPA.Hubspot** (:issue:`1106`): Extract the ``RPA.Hubspot`` library out of the
   main package and into its own package ``rpaframework-hubspot``. This is a breaking
   change, please update your ``conda.yaml`` accordingly.

--- a/packages/main/src/RPA/Crypto.py
+++ b/packages/main/src/RPA/Crypto.py
@@ -144,7 +144,7 @@ class Crypto:
         if encryption_type == EncryptionType.FERNET:
             return Fernet.generate_key().decode("utf-8")
         elif encryption_type == EncryptionType.AES256:
-            return self._generate_aes256_key()
+            return self._generate_aes256_key().decode("utf-8")
         else:
             raise UnknownEncryptionTypeError
 
@@ -343,10 +343,12 @@ class Crypto:
 
             if encoding is not None:
                 text = text.decode(encoding)
-
             return text
         elif encryption_type == EncryptionType.AES256:
-            return self._decrypt_aes256(data)
+            text = self._decrypt_aes256(data)
+            if encoding is not None:
+                text = text.decode(encoding)
+            return text
         else:
             raise UnknownEncryptionTypeError
 


### PR DESCRIPTION
This fix has been implemented to sync with how Fernet encryption method works.