### PR TITLE
`RPA.Outlook.Application` Add parameters `reply_to` and `check_names` to the `Send email` keyword

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -15,6 +15,12 @@ Latest versions
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+28.1.0 - 12 Jan 2024
+--------------------
+
+- Library **RPA.Outlook.Application** (:pr:`1144`): Add ``reply_to`` and ``check_names``
+  parameters for ``Send Email``.
+
 28.0.0 - 18 Dec 2023
 --------------------
 

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rpaframework"
-version = "28.0.0"
+version = "28.1.0"
 description = "A collection of tools and libraries for RPA"
 authors = ["RPA Framework <rpafw@robocorp.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
example on `check_names=True`
```robotframework
Send Email    mmmmm@robocorp;mika.hanninen@gmail.com;domain.com    subject    body    check_names=True
```
results in the exception message
```shell
InvalidNamesError: Failed to resolve recipient(s): mmmmm@robocorp;domain.com
```

example on `reply_to`, when email is received and replied, the replies will be sent to `reply_to` addresses
```robotframework
@{recipients}=    Create List    mika.hanninen@gmail.com   
Send Email    ${recipients}    subject=subject    body=body
...    reply_to=robocorp.developer@gmail.com;mika.hanninen@gmail.com
```