### PR TITLE
fix documentation links

### DIFF
--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -1956,7 +1956,7 @@ class Selenium(SeleniumLibrary):
         The keyword `Attach Chrome Browser` can be used to
         access an already open browser with Selenium keywords.
 
-        Read more: https://robocorp.com/docs/development-guide/browser/how-to-attach-to-running-chrome-browser
+        Read more: https://robocorp.com/portal/tutorial/how-to-attach-to-running-chrome-browser
 
         ``url`` URL to open
         ``tab`` defines is url is opened in a tab (defaults to ``True``) or
@@ -2043,9 +2043,9 @@ class Selenium(SeleniumLibrary):
         if download_pdf:
             # Disable the viewer when downloading is preferred instead of viewing.
             firefox_prefs["browser.download.viewableInternally.enabledTypes"] = ""
-            firefox_prefs[
-                "browser.helperApps.neverAsk.saveToDisk"
-            ] += " application/pdf"
+            firefox_prefs["browser.helperApps.neverAsk.saveToDisk"] += (
+                " application/pdf"
+            )
         self.download_preferences = {
             "firefox": firefox_prefs,
         }

--- a/packages/main/src/RPA/Desktop/Windows.py
+++ b/packages/main/src/RPA/Desktop/Windows.py
@@ -216,7 +216,7 @@ class Windows(OperatingSystem):
         deprecation(
             "`RPA.Desktop.Windows` got deprecated and will be no longer maintained, "
             "please use `RPA.Windows` instead "
-            "(https://robocorp.com/docs/libraries/rpa-framework/rpa-windows)"
+            "(https://robocorp.com/docs-robot-framework/libraries/rpa-framework/rpa-windows)"
         )
 
         OperatingSystem.__init__(self)

--- a/packages/main/src/RPA/Desktop/__init__.py
+++ b/packages/main/src/RPA/Desktop/__init__.py
@@ -158,8 +158,8 @@ class Desktop(DynamicCore):
 
     Read more on identifying elements and crafting locators:
 
-    - `Desktop automation and RPA <https://robocorp.com/docs/development-guide/desktop>`_
-    - `How to find user interface elements using locators and keyboard shortcuts in Windows applications <https://robocorp.com/docs/development-guide/desktop/how-to-find-user-interface-elements-using-locators-and-keyboard-shortcuts-in-windows-applications>`_
+    - `Desktop automation and RPA <https://robocorp.com/docs-robot-framework/development-guide/desktop>`_
+    - `How to find user interface elements using locators and keyboard shortcuts in Windows applications <https://robocorp.com/docs-robot-framework/development-guide/desktop/how-to-find-user-interface-elements-using-locators-and-keyboard-shortcuts-in-windows-applications>`_
 
     .. _VSCode: https://robocorp.com/docs/developer-tools/visual-studio-code/overview
 

--- a/packages/main/src/RPA/Email/ImapSmtp.py
+++ b/packages/main/src/RPA/Email/ImapSmtp.py
@@ -201,7 +201,7 @@ class ImapSmtp(OAuthMixin):
     to given criteria.
 
     Syntax needs to according to specification and more information about that
-    can be read from https://robocorp.com/docs/development-guide/email/sending-emails-with-gmail-smtp#listing-email-messages-by-criteria
+    can be read from https://robocorp.com/docs-robot-framework/development-guide/email/sending-emails-with-gmail-smtp#listing-email-messages-by-criteria
 
     **Troubleshooting**
 

--- a/packages/main/src/RPA/JavaAccessBridge.py
+++ b/packages/main/src/RPA/JavaAccessBridge.py
@@ -375,8 +375,8 @@ class JavaAccessBridge:
     .. _Accessibility Insights for Windows: https://accessibilityinsights.io/en/downloads/
     .. _Access Bridge Explorer: https://github.com/google/access-bridge-explorer
     .. _using Accessibility Insights: https://accessibilityinsights.io/docs/en/windows/reference/faq/#can-i-use-accessibility-insights-for-windows-on-a-windows-app-written-with-java
-    .. _RPA.Windows: https://robocorp.com/docs/libraries/rpa-framework/rpa-windows
-    .. _Java locators: https://robocorp.com/docs/development-guide/locators#java-locators
+    .. _RPA.Windows: https://robocorp.com/docs-robot-framework/libraries/rpa-framework/rpa-windows
+    .. _Java locators: https://robocorp.com/docs-robot-framework/development-guide/locators#java-locators
 
     **Examples**
 

--- a/packages/main/src/RPA/Robocorp/Vault.py
+++ b/packages/main/src/RPA/Robocorp/Vault.py
@@ -211,13 +211,13 @@ def _raise_invalid_configuration():
             " file.\n\n"
             "Consult the 'Configure file vault support' section in the documentation"
             " for step-by-step setup instructions:\n"
-            "https://robocorp.com/docs/development-guide/"
+            "https://robocorp.com/docs-robot-framework/development-guide/"
             "variables-and-secrets/vault\n\n"
             "When running from the Control Room, these variables should be "
             "configured automatically.\n"
             "If running with Robocorp Visual Studio Code extension, ensure that"
             " the project is linked to Control Room:\n"
-            "https://robocorp.com/docs/developer-tools/visual-studio-code/"
+            "https://robocorp.com/docs-robot-framework/developer-tools/visual-studio-code/"
             "extension-features#linking-to-control-room"
         )
 
@@ -487,8 +487,8 @@ class Vault:
     - ``RC_API_SECRET_TOKEN``: API Token for Robocorp Vault API
     - ``RC_WORKSPACE_ID``: Control Room Workspace ID
 
-    .. _Robocorp Control Room Vault: https://robocorp.com/docs/development-guide/variables-and-secrets/vault
-    .. _Robocorp Code Extension: https://robocorp.com/docs/developer-tools/visual-studio-code/extension-features#connecting-to-control-room-vault
+    .. _Robocorp Control Room Vault: https://robocorp.com/docs-robot-framework/development-guide/variables-and-secrets/vault
+    .. _Robocorp Code Extension: https://sema4.ai/docs/automation/visual-studio-code/extension-features#connecting-to-control-room-vault
     .. _rcc: https://robocorp.com/docs/rcc/workflow
 
     File-based secrets can be set by defining two environment variables.

--- a/packages/main/src/RPA/Robocorp/WorkItems.py
+++ b/packages/main/src/RPA/Robocorp/WorkItems.py
@@ -423,7 +423,7 @@ class FileAdapter(BaseAdapter):
                 deprecation(
                     "Work items load - Old path style usage detected, please use the "
                     "'RPA_INPUT_WORKITEM_PATH' env var instead "
-                    "(more details under documentation: https://robocorp.com/docs/development-guide/control-room/data-pipeline#developing-with-work-items-locally)"  # noqa: E501
+                    "(more details under documentation: https://robocorp.com/docs-robot-framework/development-guide/control-room/work-items#developing-with-work-items-locally)"  # noqa: E501
                 )
             path = os.getenv("RPA_INPUT_WORKITEM_PATH", default=old_path)
             if path:
@@ -448,7 +448,7 @@ class FileAdapter(BaseAdapter):
                 deprecation(
                     "Work items save - Old path style usage detected, please use the "
                     "'RPA_OUTPUT_WORKITEM_PATH' env var instead "
-                    "(more details under documentation: https://robocorp.com/docs/development-guide/control-room/data-pipeline#developing-with-work-items-locally)"  # noqa: E501
+                    "(more details under documentation: https://robocorp.com/docs-robot-framework/development-guide/control-room/work-items#developing-with-work-items-locally)"  # noqa: E501
                 )
                 if not self.input_path:
                     raise RuntimeError(
@@ -770,7 +770,7 @@ class WorkItems:
     the ``parsedEmail[Body]``.
 
     E-mail attachments will be added into the work item as files. Read more on:
-    https://robocorp.com/docs/control-room/attended-or-unattended/email-trigger
+    https://robocorp.com/docs-robot-framework/control-room/unattended/email-trigger
 
     Example:
 
@@ -868,9 +868,9 @@ class WorkItems:
     `Developing with work items locally`_ section of the
     `Using work items`_ development guide.
 
-    .. _Robocorp Code extension: https://robocorp.com/docs/setup/development-environment#visual-studio-code-with-robocorp-extensions
-    .. _Developing with work items locally: https://robocorp.com/docs/development-guide/control-room/work-items#developing-with-work-items-locally
-    .. _Using work items: https://robocorp.com/docs/development-guide/control-room/work-items
+    .. _Robocorp Code extension: https://robocorp.com/docs-robot-framework/developer-tools/visual-studio-code/extension-features
+    .. _Developing with work items locally: https://robocorp.com/docs-robot-framework/development-guide/control-room/work-items#developing-with-work-items-locally
+    .. _Using work items: https://robocorp.com/docs-robot-framework/development-guide/control-room/work-items
 
     **Examples**
 
@@ -1044,8 +1044,8 @@ class WorkItems:
                         deprecation(
                             "Legacy non-parsed e-mail trigger detected! Please enable "
                             '"Parse email" configuration option in Control Room. (more'
-                            " details: https://robocorp.com/docs/control-room/attended"
-                            "-or-unattended/email-trigger#parse-email)"
+                            " details: https://robocorp.com/docs-robot-framework/control-room/"
+                            "unattended/email-trigger#parse-email)"
                         )
                     output_keys = to_tuple(output_keys)
                     return content, parsed, output_keys

--- a/packages/main/src/RPA/application.py
+++ b/packages/main/src/RPA/application.py
@@ -105,7 +105,6 @@ class BaseApplication(metaclass=MetaApplication):
     Check the documentation below for more info:
 
     - https://robocorp.com/docs/control-room/unattended/worker-setups/windows-desktop
-    - https://robocorp.com/docs/faq/windows-server-2016
     """
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"

--- a/packages/windows/src/RPA/Windows/__init__.py
+++ b/packages/windows/src/RPA/Windows/__init__.py
@@ -33,10 +33,10 @@ class Windows(WindowsElementsMixin, DynamicCore):
         channels:
           - conda-forge
         dependencies:
-          - python=3.9.13
-          - pip=22.1.2
+          - python=3.12.8
+          - pip=24.3.1
           - pip:
-            - rpaframework-windows==7.0.2 # standalone Windows library (`rpaframework` includes this library)
+            - rpaframework-windows==8.0.0 # standalone Windows library (`rpaframework` includes this library)
 
 
     **About terminology**
@@ -391,7 +391,7 @@ class Windows(WindowsElementsMixin, DynamicCore):
     A more programmatic approach is to run ``Print Tree    log_as_warnings=${True}``
     keyword and then observe in the logs the found elements structure starting from
     Desktop (or the currently set anchor / active window) as root. (refer to keyword's
-    `documentation <https://robocorp.com/docs/libraries/rpa-framework/rpa-windows/keywords#print-tree>`_
+    `documentation <https://robocorp.com/docs-robot-framework/libraries/rpa-framework/rpa-windows/keywords#print-tree>`_
     for more details)
 
     .. _Accessibility Insights: https://accessibilityinsights.io/


### PR DESCRIPTION
Fix broken links in library documentation
* Remove non-existing link from [application.py](packages/main/src/RPA/application.py)
* Update links in [JavaAccessBridge](packages/main/src/RPA/JavaAccessBridge.py)
* Update link in [Selenium](packages/main/src/RPA/Browser/Selenium.py)
* Update links in [Desktop](packages/main/src/RPA/Desktop/__init__.py)
* Update links in [Email.ImapSmtp](packages/main/src/RPA/Email/ImapSmtp.py)
* Update links in [Robocorp.Vault](packages/main/src/RPA/Robocorp/Vault.py)
* Update links in [Robocorp.Workitems](packages/main/src/RPA/Robocorp/WorkItems.py)
* Update link in [widows](packages/windows/src/RPA/Windows/__init__.py)