### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/pip.yaml
+++ b/.github/workflows/pip.yaml
@@ -61,8 +61,9 @@ jobs:
           python -m pip_audit --no-deps -r requirements.txt
         # Only run scans for latest template version from https://github.com/robocorp/template-standard/blob/master/conda.yaml
         if: ${{ matrix.python-version == '3.10.11' && matrix.pip-version == '24.2' }}
-      - uses: actions/upload-artifact@v3 # v4 has issue with artifact already existing
+      - uses: actions/upload-artifact@v4
         if: ${{ success() || failure() }}
         with:
           name: pip_freeze_${{ matrix.python-version }}_${{ matrix.pip-version }}.txt
           path: requirements.txt
+          overwrite: true


### PR DESCRIPTION
Currently, the "daily installation tests" github action is disabled because it no longer works (see e.g. https://github.com/robocorp/rpaframework/actions/runs/13963050710 )

I *think* this PR restores the desired behavior, per https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact (linked from the failure notification). If not, guidance can be found in that document.