### PR TITLE
fix: relax selenium exact pin to allow Appium 3 compatibility (#1312)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -119,6 +119,61 @@ jobs:
           name: ${{ matrix.os }}-py${{ matrix.python }}-test-reports
           path: packages/main/tests/results
 
+  build-wheel:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        run: pip install uv
+      - name: Build wheel
+        run: uv build --wheel
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpaframework-wheel
+          path: packages/main/dist/*.whl
+          retention-days: 14
+      - name: Comment on PR with artifact link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const marker = '<!-- rpaframework-wheel-artifact -->';
+            const body = [
+              marker,
+              '## Wheel artifact',
+              '',
+              `Built from commit \`${sha}\` — download from the [workflow run](${runUrl}) (Artifacts section at the bottom of the page).`,
+              '',
+              'Artifact name: `rpaframework-wheel` (retained 14 days)',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+
   # publish:
   #   # Only publish on master workflow runs
   #   if: github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -126,6 +126,10 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install uv
         run: pip install uv
         working-directory: "."

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,8 +128,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install uv
         run: pip install uv
+        working-directory: "."
       - name: Build wheel
         run: uv build --wheel
+        working-directory: packages/main
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rpaframework-core"
-version = "12.1.0"
+version = "12.1.1"
 description = "Core utilities used by RPA Framework"
 authors = [{name = "RPA Framework", email = "rpafw@robocorp.com"}]
 license = {text = "Apache-2.0"}

--- a/packages/core/src/RPA/core/webdriver.py
+++ b/packages/core/src/RPA/core/webdriver.py
@@ -33,10 +33,11 @@ from webdriver_manager.core.utils import (
     windows_browser_apps_to_cmd,
 )
 from webdriver_manager.drivers.chrome import ChromeDriver as _ChromeDriver
+from webdriver_manager.drivers.edge import EdgeChromiumDriver as _EdgeChromiumDriver
 from webdriver_manager.drivers.ie import IEDriver as _IEDriver
 from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.microsoft import (
-    EdgeChromiumDriverManager,
+    EdgeChromiumDriverManager as _EdgeChromiumDriverManager,
     IEDriverManager as _IEDriverManager,
 )
 from webdriver_manager.opera import OperaDriverManager
@@ -300,6 +301,46 @@ class ChromeDriverManager(_ChromeDriverManager):
             file = self._download_manager.download_file(resolved_url)
             binary_path = self._cache_manager.save_file_to_cache(driver, file)
             return binary_path
+
+
+class EdgeChromiumDriver(_EdgeChromiumDriver):
+    """Strips the UTF-16 BOM that Microsoft's LATEST_RELEASE endpoint prepends.
+
+    webdriver-manager 4.0.2 calls ``resp.text.rstrip()`` on the response from
+    ``https://msedgedriver.microsoft.com/LATEST_RELEASE_<major>_WINDOWS``.
+    That endpoint returns a UTF-16 LE response (BOM ``\\xff\\xfe``), which
+    ``requests`` decodes to a string starting with ``\\ufeff`` (the BOM
+    codepoint). ``.rstrip()`` only strips trailing whitespace, leaving the
+    leading ``\\ufeff`` intact.  When that BOM-prefixed version is interpolated
+    into the download URL it becomes ``%EF%BB%BF145.0.3800.97/...`` which
+    returns 404.
+    """
+
+    @staticmethod
+    def _strip_bom(text: str) -> str:
+        return text.strip().lstrip("\ufeff")
+
+    def get_stable_release_version(self) -> str:
+        return self._strip_bom(super().get_stable_release_version())
+
+    def get_latest_release_version(self) -> str:
+        return self._strip_bom(super().get_latest_release_version())
+
+
+class EdgeChromiumDriverManager(_EdgeChromiumDriverManager):
+    """Custom Edge driver manager that uses :class:`EdgeChromiumDriver`."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        original = self.driver
+        self.driver = EdgeChromiumDriver(
+            name=getattr(original, "_name", "msedgedriver"),
+            driver_version=getattr(original, "_driver_version_to_download", None),
+            url=getattr(original, "_url", None),
+            latest_release_url=getattr(original, "_latest_release_url", None),
+            http_client=self.http_client,
+            os_system_manager=getattr(original, "_os_system_manager", None),
+        )
 
 
 class IEDriver(_IEDriver):
@@ -663,7 +704,7 @@ AVAILABLE_DRIVERS = {
     "opera": OperaDriverManager,
     # NOTE: In Selenium 4 `Edge` is the same with `ChromiumEdge`.
     "edge": EdgeChromiumDriverManager,
-    "chromiumedge": EdgeChromiumDriverManager,
+    "chromiumedge": EdgeChromiumDriverManager,  # uses BOM-stripping subclass
     # NOTE: IE is discontinued and not supported/encouraged anymore.
     "ie": IEDriverManager,
 }

--- a/packages/core/tests/python/test_edge_driver.py
+++ b/packages/core/tests/python/test_edge_driver.py
@@ -59,10 +59,22 @@ def main() -> int:
     # Step 2: start a headless Edge session — requires Edge browser to be installed
     edge_binary = shutil.which("msedge") or shutil.which("microsoft-edge")
     if not edge_binary:
-        # Also check the standard macOS application path
+        # Check standard macOS application path
         macos_edge = Path("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge")
         if macos_edge.exists():
             edge_binary = str(macos_edge)
+    if not edge_binary:
+        # Check standard Windows installation paths (msedge.exe is not on PATH by default)
+        import os
+        windows_paths = [
+            Path(os.environ.get("PROGRAMFILES(X86)", "")) / "Microsoft/Edge/Application/msedge.exe",
+            Path(os.environ.get("PROGRAMFILES", "")) / "Microsoft/Edge/Application/msedge.exe",
+            Path(os.environ.get("LOCALAPPDATA", "")) / "Microsoft/Edge/Application/msedge.exe",
+        ]
+        for p in windows_paths:
+            if p.exists():
+                edge_binary = str(p)
+                break
 
     if not edge_binary:
         print(

--- a/packages/core/tests/python/test_edge_driver.py
+++ b/packages/core/tests/python/test_edge_driver.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Standalone EdgeDriver integration test for issue #1312.
+
+Verifies that:
+  1. EdgeDriver binary can be downloaded (tests azureedge.net -> microsoft.com
+     redirect fix from PR #1227) — this is the primary test
+  2. A headless Edge session can be started (end-to-end, requires Edge browser installed)
+
+Expected to FAIL with selenium==4.15.2 exact pin (old azureedge.net CDN issues).
+Expected to PASS after fix: selenium>=4.15.2,<5.0.0 (newer version resolved).
+
+Exit codes:
+    0 — download succeeded (session also started if Edge browser is installed)
+    1 — download or session failed unexpectedly
+
+Usage:
+    python test_edge_driver.py
+    # or from packages/core directory:
+    uv run python tests/python/test_edge_driver.py
+"""
+import shutil
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    import importlib.metadata
+
+    selenium_ver = importlib.metadata.version("selenium")
+    print(f"Selenium version: {selenium_ver}")
+
+    # Step 1: download EdgeDriver — exercises the azureedge.net redirect patch
+    try:
+        from RPA.core import webdriver
+
+        results_dir = Path(__file__).parent / "results"
+        results_dir.mkdir(exist_ok=True)
+        print("Downloading EdgeDriver...")
+        driver_path = webdriver.download("Edge", root=results_dir)
+        print(f"  Driver downloaded: {driver_path}")
+    except Exception as exc:
+        print(f"\nFAIL (download): {type(exc).__name__}: {exc}")
+        return 1
+
+    # Step 2: start a headless Edge session — requires Edge browser to be installed
+    edge_binary = shutil.which("msedge") or shutil.which("microsoft-edge")
+    if not edge_binary:
+        # Also check the standard macOS application path
+        macos_edge = Path("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge")
+        if macos_edge.exists():
+            edge_binary = str(macos_edge)
+
+    if not edge_binary:
+        print(
+            "\nPASS (download only): EdgeDriver downloaded successfully. "
+            "Edge browser not installed — skipping session test."
+        )
+        return 0
+
+    try:
+        from selenium import webdriver as selenium_webdriver
+        from selenium.webdriver import EdgeOptions
+        from selenium.webdriver.edge.service import Service
+
+        options = EdgeOptions()
+        options.add_argument("--headless=new")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.binary_location = edge_binary
+        service = Service(driver_path)
+        print(f"Starting headless Edge session (binary: {edge_binary})...")
+        driver = selenium_webdriver.Edge(service=service, options=options)
+        try:
+            driver.get("about:blank")
+            title = driver.title
+        finally:
+            driver.quit()
+        print(f"  Session OK, page title: '{title}'")
+    except Exception as exc:
+        print(f"\nFAIL (session): {type(exc).__name__}: {exc}")
+        return 1
+
+    print("\nPASS: EdgeDriver download and session both work correctly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/core/tests/python/test_edge_driver.py
+++ b/packages/core/tests/python/test_edge_driver.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""Standalone EdgeDriver integration test for issue #1312.
+"""Standalone EdgeDriver integration test for issues #1312 and BOM bug.
 
 Verifies that:
-  1. EdgeDriver binary can be downloaded (tests azureedge.net -> microsoft.com
+  1. Microsoft's LATEST_RELEASE endpoint BOM is stripped before building the
+     download URL — without the fix, the URL contains %EF%BB%BF and returns 404
+  2. EdgeDriver binary can be downloaded (tests azureedge.net -> microsoft.com
      redirect fix from PR #1227) — this is the primary test
-  2. A headless Edge session can be started (end-to-end, requires Edge browser installed)
+  3. A headless Edge session can be started (end-to-end, requires Edge browser installed)
 
-Expected to FAIL with selenium==4.15.2 exact pin (old azureedge.net CDN issues).
-Expected to PASS after fix: selenium>=4.15.2,<5.0.0 (newer version resolved).
+Expected to FAIL without the BOM-strip fix (webdriver-manager 4.0.2 bug).
+Expected to PASS after fix: EdgeChromiumDriver.get_latest_release_version() strips \\ufeff.
 
 Exit codes:
     0 — download succeeded (session also started if Edge browser is installed)
@@ -28,6 +30,18 @@ def main() -> int:
 
     selenium_ver = importlib.metadata.version("selenium")
     print(f"Selenium version: {selenium_ver}")
+
+    # Step 0: verify BOM-strip fix in EdgeChromiumDriver
+    print("Checking BOM strip in EdgeChromiumDriver...")
+    try:
+        from RPA.core.webdriver import EdgeChromiumDriver
+        bom_version = "\ufeff145.0.3800.97"
+        stripped = EdgeChromiumDriver._strip_bom(bom_version)
+        assert stripped == "145.0.3800.97", f"BOM not stripped: {stripped!r}"
+        print(f"  BOM strip OK: {bom_version!r} -> {stripped!r}")
+    except Exception as exc:
+        print(f"\nFAIL (BOM strip check): {type(exc).__name__}: {exc}")
+        return 1
 
     # Step 1: download EdgeDriver — exercises the azureedge.net redirect patch
     try:

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 	"mss>=6.0.0",
 	"chardet>=3.0.0",
 	"PySocks>=1.5.6,!=1.5.7,<2.0.0",
-	"selenium>=4.15.2,<5.0.0",
+	"selenium>=4.16.0,<5.0.0",
 	"click>=8.1.2",
 	"PyYAML>=5.4.1,<7.0.0",
 	"tenacity>=8.0.1",

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rpaframework"
-version = "31.1.2"
+version = "31.2.0"
 description = "A collection of tools and libraries for RPA"
 authors = [{name = "RPA Framework", email = "rpafw@robocorp.com"}]
 license = {text = "Apache-2.0"}
@@ -60,7 +60,7 @@ dependencies = [
 	"mss>=6.0.0",
 	"chardet>=3.0.0",
 	"PySocks>=1.5.6,!=1.5.7,<2.0.0",
-	"selenium==4.15.2",
+	"selenium>=4.15.2,<5.0.0",
 	"click>=8.1.2",
 	"PyYAML>=5.4.1,<7.0.0",
 	"tenacity>=8.0.1",

--- a/packages/main/scripts/ai-review.sh
+++ b/packages/main/scripts/ai-review.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# AI code review — runs Claude against the current branch diff (vs master).
+#
+# Usage:
+#   ./packages/main/scripts/ai-review.sh          # review all changes vs master
+#   ./packages/main/scripts/ai-review.sh --staged  # review only staged changes
+#
+# Called automatically by pre-push.sh; can also be run standalone.
+# Requires `claude` (Claude Code CLI) to be on PATH.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BASE_BRANCH="${AI_REVIEW_BASE:-master}"
+STAGED_ONLY="${1:-}"
+
+if ! command -v claude &>/dev/null; then
+    echo ">>> ai-review: 'claude' not found on PATH — skipping AI review."
+    exit 0
+fi
+
+# Build the diff
+if [[ "$STAGED_ONLY" == "--staged" ]]; then
+    DIFF="$(git -C "$REPO_ROOT" diff --cached)"
+    DIFF_LABEL="staged changes"
+else
+    DIFF="$(git -C "$REPO_ROOT" diff "$BASE_BRANCH"...HEAD)"
+    DIFF_LABEL="changes vs $BASE_BRANCH"
+fi
+
+if [[ -z "$DIFF" ]]; then
+    echo ">>> ai-review: no diff found ($DIFF_LABEL) — skipping."
+    exit 0
+fi
+
+DIFF_LINES="$(echo "$DIFF" | wc -l | tr -d ' ')"
+echo ">>> Running AI review on $DIFF_LABEL ($DIFF_LINES lines of diff)..."
+
+PROMPT="You are a senior Python code reviewer. Review the following git diff carefully.
+
+Focus ONLY on real problems (not style nits). Flag:
+- Wrong exception types raised (e.g. built-in TimeoutError instead of selenium TimeoutException)
+- Missing guards for platform/driver-specific APIs (e.g. Chromium-only features called on Firefox)
+- Misleading or incorrect error messages
+- Import errors or removed APIs used
+- Security issues (command injection, SQL injection, XSS, path traversal, etc.)
+- Logic bugs that would cause test failures or silent misbehaviour
+- CI/CD configuration mistakes (wrong working-directory, missing permissions, etc.)
+
+Format your response as a concise bulleted list. If there are no issues, say 'No issues found.'
+Group by severity: [HIGH], [MEDIUM], [LOW].
+
+GIT DIFF:
+$DIFF"
+
+# Unset CLAUDECODE so this can run inside a Claude Code session (e.g. during /review)
+echo "$PROMPT" | env -u CLAUDECODE claude --print --output-format text
+EXIT_CODE=$?
+
+echo ""
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo ">>> ai-review: claude exited with code $EXIT_CODE."
+fi
+exit 0  # AI review is advisory — never block the push

--- a/packages/main/scripts/ai-review.sh
+++ b/packages/main/scripts/ai-review.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 BASE_BRANCH="${AI_REVIEW_BASE:-master}"
+if ! [[ "$BASE_BRANCH" =~ ^[A-Za-z0-9/_.-]+$ ]]; then
+    echo ">>> ai-review: invalid AI_REVIEW_BASE value '$BASE_BRANCH' — aborting." >&2
+    exit 1
+fi
 STAGED_ONLY="${1:-}"
 
 if ! command -v claude &>/dev/null; then

--- a/packages/main/scripts/pre-push.sh
+++ b/packages/main/scripts/pre-push.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Pre-push hook for packages/main — runs lint and fast (non-browser) tests locally.
+# Pre-push hook for packages/main — runs lint, fast tests, and AI review locally.
 # Install: cp packages/main/scripts/pre-push.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# Skip AI review: AI_REVIEW=0 git push
 
 set -e
-cd "$(git rev-parse --show-toplevel)/packages/main"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT/packages/main"
 
 echo ">>> Running pylint..."
 uv run pylint --rcfile ../../config/pylint src
@@ -12,5 +14,10 @@ echo ">>> Running fast tests (no browser required)..."
 uv run pytest tests/python/test_browser.py \
     -k "not (TestSelenium or TestRelativeLocators or TestBrowserLogs or TestNetworkInterception or TestVirtualAuthenticator)" \
     -v
+
+# AI review (advisory — never blocks the push; set AI_REVIEW=0 to skip)
+if [[ "${AI_REVIEW:-1}" != "0" ]]; then
+    bash "$REPO_ROOT/packages/main/scripts/ai-review.sh"
+fi
 
 echo ">>> OK — pushing."

--- a/packages/main/scripts/pre-push.sh
+++ b/packages/main/scripts/pre-push.sh
@@ -3,7 +3,7 @@
 # Install: cp packages/main/scripts/pre-push.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 # Skip AI review: AI_REVIEW=0 git push
 
-set -e
+set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT/packages/main"
 

--- a/packages/main/scripts/pre-push.sh
+++ b/packages/main/scripts/pre-push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pre-push hook for packages/main — runs lint and fast (non-browser) tests locally.
+# Install: cp packages/main/scripts/pre-push.sh .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+
+set -e
+cd "$(git rev-parse --show-toplevel)/packages/main"
+
+echo ">>> Running pylint..."
+uv run pylint --rcfile ../../config/pylint src
+
+echo ">>> Running fast tests (no browser required)..."
+uv run pytest tests/python/test_browser.py \
+    -k "not (TestSelenium or TestRelativeLocators or TestBrowserLogs or TestNetworkInterception or TestVirtualAuthenticator)" \
+    -v
+
+echo ">>> OK — pushing."

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -2194,6 +2194,11 @@ class Selenium(SeleniumLibrary):
         return self._send_command_and_get_result(command, parameters)
 
     def _send_command_and_get_result(self, cmd, params):
+        if not self.is_chromium:
+            raise NotImplementedError(
+                f"CDP command '{cmd}' requires a Chromium-based browser"
+                f" (Chrome, Edge), got: {self.driver.name}."
+            )
         return self.driver.execute_cdp_cmd(cmd, params)
 
     @keyword
@@ -2560,12 +2565,13 @@ class Selenium(SeleniumLibrary):
                 f"Invalid transport '{transport}'. "
                 f"Valid values: {', '.join(sorted(_VALID_TRANSPORTS))}."
             )
-        options = VirtualAuthenticatorOptions()
-        options.protocol = protocol
-        options.transport = transport
-        options.has_resident_key = has_resident_key
-        options.has_user_verification = has_user_verification
-        options.is_user_verified = is_user_verified
+        options = VirtualAuthenticatorOptions(
+            protocol=protocol,
+            transport=transport,
+            has_resident_key=has_resident_key,
+            has_user_verification=has_user_verification,
+            is_user_verified=is_user_verified,
+        )
         self.driver.add_virtual_authenticator(options)
         return self.driver.virtual_authenticator_id
 

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -22,13 +22,11 @@ from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from selenium import webdriver as selenium_webdriver
 from selenium.common import WebDriverException
 from selenium.common.exceptions import ElementClickInterceptedException
-from selenium.webdriver import (
-    ChromeOptions,
-    EdgeOptions,
-    FirefoxOptions as _FirefoxOptions,
-    FirefoxProfile,
-    IeOptions,
-)
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
+from selenium.webdriver.firefox.options import Options as _FirefoxOptions
+from selenium.webdriver.ie.options import Options as IeOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import ArgOptions
 from selenium.webdriver.common.virtual_authenticator import VirtualAuthenticatorOptions
@@ -101,13 +99,9 @@ class RobocorpElementFinder(ElementFinder):
         return isinstance(element, ShadowRoot) or super()._is_webelement(element)
 
 
-class FirefoxOptions(_FirefoxOptions):
-    """Wrapped Firefox options in order to fix behavior."""
-
-    @property
-    def binary_location(self) -> Optional[str]:
-        # pylint: disable=protected-access
-        return self.binary._start_cmd if self.binary else None
+# In selenium >=4.16, FirefoxOptions.binary_location is a native string property;
+# the binary._start_cmd workaround is no longer needed.
+FirefoxOptions = _FirefoxOptions
 
 
 class BrowserManagementKeywords(_BrowserManagementKeywords):

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -2198,15 +2198,7 @@ class Selenium(SeleniumLibrary):
         return self._send_command_and_get_result(command, parameters)
 
     def _send_command_and_get_result(self, cmd, params):
-        resource = (
-            f"session/{self.driver.session_id}/chromium/send_command_and_get_result"
-        )
-        # pylint: disable=protected-access
-        url = f"{self.driver.command_executor._url}/{resource}"
-        body = json.dumps({"cmd": cmd, "params": params})
-        response = self.driver.command_executor._request("POST", url, body)
-
-        return response.get("value")
+        return self.driver.execute_cdp_cmd(cmd, params)
 
     @keyword
     def set_element_attribute(

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from selenium import webdriver as selenium_webdriver
 from selenium.common import WebDriverException
-from selenium.common.exceptions import ElementClickInterceptedException
+from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.edge.options import Options as EdgeOptions
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
@@ -2491,7 +2491,7 @@ class Selenium(SeleniumLibrary):
                     return url
                 seen.add(url)
             time.sleep(0.5)
-        raise TimeoutError(
+        raise TimeoutException(
             f"No network request matching '{url_pattern}' detected"
             f" within {timeout_val}s"
         )

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -2404,6 +2404,13 @@ class Selenium(SeleniumLibrary):
         | Open Browser    https://example.com |
         | ...    options=set_capability('goog:loggingPrefs', {'performance': 'ALL'}) |
         """
+        _CHROMIUM_ONLY_LOG_TYPES = {"performance", "client"}
+        if log_type in _CHROMIUM_ONLY_LOG_TYPES and not self.is_chromium:
+            raise NotImplementedError(
+                f"Log type '{log_type}' is only available in Chromium-based browsers"
+                f" (Chrome, Edge), got: {self.driver.name}. "
+                f"Use log_type='browser' or 'driver' for cross-browser log retrieval."
+            )
         return self.driver.get_log(log_type)
 
     # ------------------------------------------------------------------ #
@@ -2538,6 +2545,24 @@ class Selenium(SeleniumLibrary):
         | # ... interact with WebAuthn registration or assertion flow ... |
         | Remove Virtual Authenticator |
         """
+        _VALID_PROTOCOLS = {"ctap2", "ctap1/u2f"}
+        _VALID_TRANSPORTS = {"usb", "nfc", "ble", "hybrid", "internal"}
+
+        if not self.is_chromium:
+            raise NotImplementedError(
+                "Add Virtual Authenticator requires a Chromium-based browser"
+                f" (Chrome, Edge), got: {self.driver.name}."
+            )
+        if protocol not in _VALID_PROTOCOLS:
+            raise ValueError(
+                f"Invalid protocol '{protocol}'. "
+                f"Valid values: {', '.join(sorted(_VALID_PROTOCOLS))}."
+            )
+        if transport not in _VALID_TRANSPORTS:
+            raise ValueError(
+                f"Invalid transport '{transport}'. "
+                f"Valid values: {', '.join(sorted(_VALID_TRANSPORTS))}."
+            )
         options = VirtualAuthenticatorOptions()
         options.protocol = protocol
         options.transport = transport
@@ -2553,4 +2578,9 @@ class Selenium(SeleniumLibrary):
 
         See `Add Virtual Authenticator` for the full usage example.
         """
+        if not self.is_chromium:
+            raise NotImplementedError(
+                "Remove Virtual Authenticator requires a Chromium-based browser"
+                f" (Chrome, Edge), got: {self.driver.name}."
+            )
         self.driver.remove_virtual_authenticator()

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -2370,14 +2370,17 @@ class Selenium(SeleniumLibrary):
     def get_browser_logs(self, log_type: str = "browser") -> List[Dict]:
         """Returns browser log entries for the given ``log_type``.
 
+        Requires a Chromium-based browser (Chrome or Edge). Since Selenium 4.32
+        the ``get_log`` API is only available on Chromium drivers.
+
         Each entry is a dict with keys ``level``, ``message``, ``source``,
         and ``timestamp`` (epoch milliseconds).
 
-        Available log types (browser-dependent):
+        Available log types:
 
         - ``browser`` — JavaScript console output (console.log, errors, warnings)
-        - ``performance`` — network events and rendering metrics (Chromium only,
-          must be enabled at browser open time)
+        - ``performance`` — network events and rendering metrics (must be enabled
+          at browser open time via ``goog:loggingPrefs``)
         - ``driver`` — WebDriver-level events
         - ``client`` — client-side events
 
@@ -2386,7 +2389,7 @@ class Selenium(SeleniumLibrary):
 
         Example:
 
-        | Open Available Browser    https://example.com    headless=${True} |
+        | Open Available Browser    https://example.com    browser_selection=Chrome    headless=${True} |
         | Execute Javascript    console.error("boom") |
         | ${logs}=    Get Browser Logs |
         | FOR    ${entry}    IN    @{logs} |
@@ -2398,12 +2401,12 @@ class Selenium(SeleniumLibrary):
         | Open Browser    https://example.com |
         | ...    options=set_capability('goog:loggingPrefs', {'performance': 'ALL'}) |
         """
-        _CHROMIUM_ONLY_LOG_TYPES = {"performance", "client"}
-        if log_type in _CHROMIUM_ONLY_LOG_TYPES and not self.is_chromium:
+        if not self.is_chromium:
             raise NotImplementedError(
-                f"Log type '{log_type}' is only available in Chromium-based browsers"
-                f" (Chrome, Edge), got: {self.driver.name}. "
-                f"Use log_type='browser' or 'driver' for cross-browser log retrieval."
+                f"Get Browser Logs requires a Chromium-based browser (Chrome, Edge),"
+                f" got: {self.driver.name}. "
+                f"The get_log() API is not available on non-Chromium drivers"
+                f" since Selenium 4.32."
             )
         return self.driver.get_log(log_type)
 

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -2,7 +2,6 @@
 import atexit
 import base64
 import datetime
-import json
 import logging
 import os
 import platform

--- a/packages/main/src/RPA/Browser/Selenium.py
+++ b/packages/main/src/RPA/Browser/Selenium.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 import time
@@ -30,8 +31,10 @@ from selenium.webdriver import (
 )
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.common.virtual_authenticator import VirtualAuthenticatorOptions
 from selenium.webdriver.remote.shadowroot import ShadowRoot
 from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.relative_locator import locate_with
 from selenium.webdriver.support.ui import WebDriverWait
 from SeleniumLibrary import EMBED, SeleniumLibrary, WebElement
 from SeleniumLibrary.base import keyword
@@ -2270,3 +2273,284 @@ class Selenium(SeleniumLibrary):
         """
         element = self.find_element(locator, parent=parent)
         return element.shadow_root if shadow else element
+
+    # ------------------------------------------------------------------ #
+    # Relative Locators (selenium 4.x)
+    # ------------------------------------------------------------------ #
+
+    @keyword
+    def find_element_above(self, tag: str, reference: Locator) -> WebElement:
+        """Returns the first element with the given HTML ``tag`` positioned
+        above the ``reference`` element on the page.
+
+        Uses selenium's relative locator API (available since Selenium 4).
+
+        ``tag`` HTML tag name of the element to find, e.g. ``input``, ``button``.
+
+        ``reference`` standard locator string or WebElement used as the
+        spatial reference point.
+
+        Example:
+
+        | ${field}=    Find Element Above    input    id:password-label |
+
+        See also `Find Element Below`, `Find Element To Left Of`,
+        `Find Element To Right Of`, and `Find Element Near`.
+        """
+        ref = self.find_element(reference)
+        return self.driver.find_element(locate_with(By.TAG_NAME, tag).above(ref))
+
+    @keyword
+    def find_element_below(self, tag: str, reference: Locator) -> WebElement:
+        """Returns the first element with the given HTML ``tag`` positioned
+        below the ``reference`` element on the page.
+
+        ``tag`` HTML tag name of the element to find.
+
+        ``reference`` standard locator string or WebElement used as the
+        spatial reference point.
+
+        Example:
+
+        | ${field}=    Find Element Below    input    id:username-label |
+        """
+        ref = self.find_element(reference)
+        return self.driver.find_element(locate_with(By.TAG_NAME, tag).below(ref))
+
+    @keyword
+    def find_element_to_left_of(self, tag: str, reference: Locator) -> WebElement:
+        """Returns the first element with the given HTML ``tag`` positioned
+        to the left of the ``reference`` element on the page.
+
+        ``tag`` HTML tag name of the element to find.
+
+        ``reference`` standard locator string or WebElement used as the
+        spatial reference point.
+
+        Example:
+
+        | ${label}=    Find Element To Left Of    label    id:username-input |
+        """
+        ref = self.find_element(reference)
+        return self.driver.find_element(locate_with(By.TAG_NAME, tag).to_left_of(ref))
+
+    @keyword
+    def find_element_to_right_of(self, tag: str, reference: Locator) -> WebElement:
+        """Returns the first element with the given HTML ``tag`` positioned
+        to the right of the ``reference`` element on the page.
+
+        ``tag`` HTML tag name of the element to find.
+
+        ``reference`` standard locator string or WebElement used as the
+        spatial reference point.
+
+        Example:
+
+        | ${field}=    Find Element To Right Of    input    id:username-label |
+        """
+        ref = self.find_element(reference)
+        return self.driver.find_element(locate_with(By.TAG_NAME, tag).to_right_of(ref))
+
+    @keyword
+    def find_element_near(self, tag: str, reference: Locator) -> WebElement:
+        """Returns the first element with the given HTML ``tag`` that is
+        within approximately 50 pixels of the ``reference`` element.
+
+        ``tag`` HTML tag name of the element to find.
+
+        ``reference`` standard locator string or WebElement used as the
+        spatial reference point.
+
+        Example:
+
+        | ${field}=    Find Element Near    input    id:username-label |
+        """
+        ref = self.find_element(reference)
+        return self.driver.find_element(locate_with(By.TAG_NAME, tag).near(ref))
+
+    # ------------------------------------------------------------------ #
+    # Browser Logs
+    # ------------------------------------------------------------------ #
+
+    @keyword
+    def get_browser_logs(self, log_type: str = "browser") -> List[Dict]:
+        """Returns browser log entries for the given ``log_type``.
+
+        Each entry is a dict with keys ``level``, ``message``, ``source``,
+        and ``timestamp`` (epoch milliseconds).
+
+        Available log types (browser-dependent):
+
+        - ``browser`` — JavaScript console output (console.log, errors, warnings)
+        - ``performance`` — network events and rendering metrics (Chromium only,
+          must be enabled at browser open time)
+        - ``driver`` — WebDriver-level events
+        - ``client`` — client-side events
+
+        Note: log entries are consumed on retrieval and will not appear again
+        in subsequent calls.
+
+        Example:
+
+        | Open Available Browser    https://example.com    headless=${True} |
+        | Execute Javascript    console.error("boom") |
+        | ${logs}=    Get Browser Logs |
+        | FOR    ${entry}    IN    @{logs} |
+        |     Log    ${entry}[level]: ${entry}[message] |
+        | END |
+
+        To capture ``performance`` logs, open the browser with the capability:
+
+        | Open Browser    https://example.com |
+        | ...    options=set_capability('goog:loggingPrefs', {'performance': 'ALL'}) |
+        """
+        return self.driver.get_log(log_type)
+
+    # ------------------------------------------------------------------ #
+    # Network Interception (Chromium CDP)
+    # ------------------------------------------------------------------ #
+
+    @keyword
+    def block_urls(self, *patterns: str) -> None:
+        """Blocks network requests whose URLs match the given ``patterns``.
+
+        Works only with Chromium-based browsers (Chrome, Edge).
+        Supports ``*`` wildcards, e.g. ``*analytics*``.
+
+        Use `Unblock URLs` to clear all blocks.
+
+        Example:
+
+        | Open Available Browser    https://example.com    browser_selection=Chrome    headless=${True} |
+        | Block URLs    *google-analytics*    *facebook.com/tr* |
+        | Reload Page |
+        """
+        if not self.is_chromium:
+            raise NotImplementedError(
+                "Block URLs works only with Chromium-based browsers,"
+                f" got: {self.driver.name}"
+            )
+        self.driver.execute_cdp_cmd("Network.enable", {})
+        self.driver.execute_cdp_cmd("Network.setBlockedURLs", {"urls": list(patterns)})
+
+    @keyword
+    def unblock_urls(self) -> None:
+        """Removes all URL blocks previously set by `Block URLs`.
+
+        Works only with Chromium-based browsers.
+
+        Example:
+
+        | Block URLs    *analytics* |
+        | Reload Page |
+        | Unblock URLs |
+        """
+        if not self.is_chromium:
+            raise NotImplementedError(
+                "Unblock URLs works only with Chromium-based browsers,"
+                f" got: {self.driver.name}"
+            )
+        self.driver.execute_cdp_cmd("Network.setBlockedURLs", {"urls": []})
+
+    @keyword
+    def wait_for_network_request(
+        self, url_pattern: str, timeout: TimeoutType = None
+    ) -> str:
+        """Waits until a completed network request URL matching ``url_pattern``
+        appears in the browser's performance resource timeline.
+
+        Polls ``window.performance.getEntriesByType('resource')``, which records
+        all completed resource loads (XHR, fetch, images, scripts, stylesheets).
+        No special browser configuration is required.
+
+        ``url_pattern`` regular expression matched against request URLs.
+
+        ``timeout`` maximum wait time; uses the library default if omitted.
+
+        Returns the first matched URL string.
+
+        Example:
+
+        | Open Available Browser    https://example.com    headless=${True} |
+        | Click Button    id:load-data |
+        | ${url}=    Wait For Network Request    /api/v1/data |
+        | Log    Captured: ${url} |
+        """
+        timeout_val: float = self.browser_management.get_timeout(timeout)
+        pattern = re.compile(url_pattern)
+        end_time = time.time() + timeout_val
+        seen: set = set()
+        while time.time() < end_time:
+            urls: List[str] = self.driver.execute_script(
+                "return window.performance"
+                ".getEntriesByType('resource').map(r => r.name);"
+            )
+            for url in urls:
+                if url not in seen and pattern.search(url):
+                    return url
+                seen.add(url)
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"No network request matching '{url_pattern}' detected"
+            f" within {timeout_val}s"
+        )
+
+    # ------------------------------------------------------------------ #
+    # Virtual Authenticator (WebAuthn / Passkey testing)
+    # ------------------------------------------------------------------ #
+
+    @keyword
+    def add_virtual_authenticator(
+        self,
+        protocol: str = "ctap2",
+        transport: str = "usb",
+        has_resident_key: bool = True,
+        has_user_verification: bool = True,
+        is_user_verified: bool = True,
+    ) -> str:
+        """Adds a virtual authenticator to the browser session for testing
+        WebAuthn / passkey flows without a physical hardware key.
+
+        Returns the authenticator ID string.
+
+        ``protocol`` authenticator protocol: ``ctap2`` (FIDO2, default) or
+        ``ctap1/u2f`` (legacy U2F).
+
+        ``transport`` connection transport: ``usb`` (default), ``nfc``, ``ble``,
+        ``hybrid``, or ``internal``.
+
+        ``has_resident_key`` whether the authenticator supports discoverable
+        credentials (resident keys). Default: ``True``.
+
+        ``has_user_verification`` whether the authenticator supports user
+        verification such as PIN or biometrics. Default: ``True``.
+
+        ``is_user_verified`` whether user verification is pre-satisfied.
+        Default: ``True``.
+
+        Use `Remove Virtual Authenticator` to clean up after the test.
+
+        Example:
+
+        | Open Available Browser    https://example.com    browser_selection=Chrome    headless=${True} |
+        | ${auth_id}=    Add Virtual Authenticator |
+        | Log    Authenticator ID: ${auth_id} |
+        | # ... interact with WebAuthn registration or assertion flow ... |
+        | Remove Virtual Authenticator |
+        """
+        options = VirtualAuthenticatorOptions()
+        options.protocol = protocol
+        options.transport = transport
+        options.has_resident_key = has_resident_key
+        options.has_user_verification = has_user_verification
+        options.is_user_verified = is_user_verified
+        self.driver.add_virtual_authenticator(options)
+        return self.driver.virtual_authenticator_id
+
+    @keyword
+    def remove_virtual_authenticator(self) -> None:
+        """Removes the virtual authenticator from the current browser session.
+
+        See `Add Virtual Authenticator` for the full usage example.
+        """
+        self.driver.remove_virtual_authenticator()

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -213,7 +213,9 @@ class TestNetworkInterception:
             "var i = new Image(); i.src = 'about:blank?rpa_test=1'; document.body.appendChild(i);"
         )
         # about:blank?... won't appear as resource; test the timeout path is correct
-        with pytest.raises((TimeoutError, Exception)):
+        from selenium.common.exceptions import TimeoutException
+
+        with pytest.raises(TimeoutException, match="nonexistent_pattern_xyz"):
             library.wait_for_network_request("nonexistent_pattern_xyz", timeout=1)
 
 
@@ -298,7 +300,7 @@ def test_selenium_api_imports():
     """
     from selenium import webdriver as selenium_webdriver  # noqa: F401
     from selenium.common import WebDriverException  # noqa: F401
-    from selenium.common.exceptions import ElementClickInterceptedException  # noqa: F401
+    from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException  # noqa: F401
     from selenium.webdriver.chrome.options import Options as ChromeOptions  # noqa: F401
     from selenium.webdriver.edge.options import Options as EdgeOptions  # noqa: F401
     from selenium.webdriver.firefox.firefox_profile import FirefoxProfile  # noqa: F401

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -96,10 +96,10 @@ class TestRelativeLocators:
         return library
 
     def test_find_element_below(self, chrome):
-        # inp-password is below lbl-username (two rows down)
+        # inp-password is the input element below lbl-username (next flex row)
         el = chrome.find_element_below("input", "id:lbl-username")
         assert el is not None
-        assert el.get_attribute("id") in ("inp-username", "inp-password")
+        assert el.get_attribute("id") == "inp-password"
 
     def test_find_element_above(self, chrome):
         el = chrome.find_element_above("label", "id:lbl-password")

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -10,6 +10,7 @@ from . import RESOURCES_DIR, temp_filename
 
 
 CHROMIUM_HEADLESS = "--headless=new"
+RELATIVE_LOCATOR_PAGE = f"file://{RESOURCES_DIR / 'relative_locator_test.html'}"
 
 
 @pytest.fixture
@@ -82,6 +83,157 @@ class TestSelenium:
         options = {"binary_location": path}
         options_obj = library.normalize_options(options, browser="Chrome")
         assert options_obj.binary_location == path
+
+
+class TestRelativeLocators:
+    """Tests for selenium 4.x relative locator keywords."""
+
+    @pytest.fixture
+    def chrome(self, library):
+        library.open_available_browser(
+            RELATIVE_LOCATOR_PAGE, headless=True, browser_selection="Chrome"
+        )
+        return library
+
+    def test_find_element_below(self, chrome):
+        # inp-password is below lbl-username (two rows down)
+        el = chrome.find_element_below("input", "id:lbl-username")
+        assert el is not None
+        assert el.get_attribute("id") in ("inp-username", "inp-password")
+
+    def test_find_element_above(self, chrome):
+        el = chrome.find_element_above("label", "id:lbl-password")
+        assert el is not None
+        assert el.get_attribute("id") == "lbl-username"
+
+    def test_find_element_to_right_of(self, chrome):
+        el = chrome.find_element_to_right_of("input", "id:lbl-username")
+        assert el.get_attribute("id") == "inp-username"
+
+    def test_find_element_to_left_of(self, chrome):
+        el = chrome.find_element_to_left_of("label", "id:inp-username")
+        assert el.get_attribute("id") == "lbl-username"
+
+    def test_find_element_near(self, chrome):
+        el = chrome.find_element_near("input", "id:lbl-username")
+        assert el is not None
+
+
+class TestBrowserLogs:
+    """Tests for Get Browser Logs keyword."""
+
+    def test_get_browser_logs_captures_console_errors(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        library.execute_javascript('console.error("rpa-test-error")')
+        logs = library.get_browser_logs(log_type="browser")
+        messages = [entry["message"] for entry in logs]
+        assert any("rpa-test-error" in m for m in messages)
+
+    def test_get_browser_logs_returns_list(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        logs = library.get_browser_logs()
+        assert isinstance(logs, list)
+
+    def test_get_browser_logs_entries_have_expected_keys(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        library.execute_javascript('console.warn("check-keys")')
+        logs = library.get_browser_logs()
+        if logs:
+            entry = logs[0]
+            assert "level" in entry
+            assert "message" in entry
+            assert "timestamp" in entry
+
+
+class TestNetworkInterception:
+    """Tests for Block URLs / Unblock URLs / Wait For Network Request keywords."""
+
+    def test_block_urls_prevents_request(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        library.block_urls("*nonexistent-blocked-domain-xyz*")
+        # Verify the call succeeded without error — actual blocking verified by
+        # checking the CDP command was accepted (no exception = success)
+
+    def test_unblock_urls_clears_blocks(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        library.block_urls("*something*")
+        library.unblock_urls()  # should not raise
+
+    def test_block_urls_raises_for_non_chromium(self, library):
+        from unittest.mock import patch, PropertyMock
+
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
+            with pytest.raises(NotImplementedError):
+                library.block_urls("*test*")
+
+    def test_wait_for_network_request(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        # Trigger a resource load via JS fetch to an always-available URL
+        library.execute_javascript(
+            "fetch('data:text/plain,ok').catch(() => {});"
+        )
+        # data: URLs appear as resources — use a more reliable approach:
+        # inject an image load instead and look for it
+        library.execute_javascript(
+            "var i = new Image(); i.src = 'about:blank?rpa_test=1'; document.body.appendChild(i);"
+        )
+        # about:blank?... won't appear as resource; test the timeout path is correct
+        with pytest.raises((TimeoutError, Exception)):
+            library.wait_for_network_request("nonexistent_pattern_xyz", timeout=1)
+
+
+class TestVirtualAuthenticator:
+    """Tests for Add/Remove Virtual Authenticator keywords."""
+
+    def test_add_and_remove_virtual_authenticator(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        auth_id = library.add_virtual_authenticator()
+        assert auth_id is not None
+        assert isinstance(auth_id, str)
+        library.remove_virtual_authenticator()
+
+    def test_add_virtual_authenticator_default_protocol(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        auth_id = library.add_virtual_authenticator(protocol="ctap2", transport="usb")
+        assert auth_id
+        library.remove_virtual_authenticator()
+
+    def test_add_virtual_authenticator_u2f(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        auth_id = library.add_virtual_authenticator(
+            protocol="ctap1/u2f", transport="usb"
+        )
+        assert auth_id
+        library.remove_virtual_authenticator()
+
+    def test_add_virtual_authenticator_internal_transport(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        auth_id = library.add_virtual_authenticator(transport="internal")
+        assert auth_id
+        library.remove_virtual_authenticator()
 
 
 def test_selenium_api_imports():

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -189,15 +189,16 @@ class TestNetworkInterception:
             with pytest.raises(NotImplementedError, match="Chromium"):
                 library.unblock_urls()
 
-    def test_get_browser_logs_performance_raises_for_non_chromium(self, library):
+    @pytest.mark.parametrize("log_type", ["browser", "performance", "driver", "client"])
+    def test_get_browser_logs_raises_for_non_chromium(self, library, log_type):
         from unittest.mock import patch, PropertyMock
 
         library.open_available_browser(
             "about:blank", headless=True, browser_selection="Chrome"
         )
         with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
-            with pytest.raises(NotImplementedError, match="performance"):
-                library.get_browser_logs(log_type="performance")
+            with pytest.raises(NotImplementedError, match="Chromium"):
+                library.get_browser_logs(log_type=log_type)
 
     def test_wait_for_network_request(self, library):
         library.open_available_browser(

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -84,6 +84,47 @@ class TestSelenium:
         assert options_obj.binary_location == path
 
 
+def test_selenium_api_imports():
+    """All selenium APIs used by RPA.Browser.Selenium must remain importable.
+
+    Regression guard: if a newer selenium 4.x removes any of these, this test fails
+    before the constraint is widened further.
+    """
+    from selenium.common import WebDriverException  # noqa: F401
+    from selenium.common.exceptions import ElementClickInterceptedException  # noqa: F401
+    from selenium.webdriver import (  # noqa: F401
+        ChromeOptions,
+        EdgeOptions,
+        FirefoxOptions,
+        FirefoxProfile,
+        IeOptions,
+    )
+    from selenium.webdriver.common.by import By  # noqa: F401
+    from selenium.webdriver.common.options import ArgOptions  # noqa: F401
+    from selenium.webdriver.remote.shadowroot import ShadowRoot  # noqa: F401
+    from selenium.webdriver.support import expected_conditions  # noqa: F401
+    from selenium.webdriver.support.ui import WebDriverWait  # noqa: F401
+
+
+def test_selenium_constraint_is_not_exact_pin():
+    """Regression: selenium must not be pinned to an exact version (issue #1312).
+
+    An exact selenium==x.y.z pin blocks users from installing packages that require
+    a different selenium version (e.g. appium-python-client for Appium 3).
+    """
+    import re
+    from pathlib import Path
+
+    pyproject = (Path(__file__).parent.parent.parent / "pyproject.toml").read_text()
+    match = re.search(r'"selenium([^"]*)"', pyproject)
+    assert match, "selenium dependency not found in pyproject.toml"
+    constraint = match.group(1)
+    assert not constraint.startswith("=="), (
+        f"selenium must not be exact-pinned; got 'selenium{constraint}'. "
+        "Exact pins block Appium 3 and other selenium-dependent packages (issue #1312)."
+    )
+
+
 @pytest.mark.parametrize(
     "url,default,scheme",
     [

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -293,22 +293,23 @@ class TestVirtualAuthenticator:
 def test_selenium_api_imports():
     """All selenium APIs used by RPA.Browser.Selenium must remain importable.
 
-    Regression guard: if a newer selenium 4.x removes any of these, this test fails
-    before the constraint is widened further.
+    Import paths must match exactly what production code uses — if selenium
+    reorganises its package structure in a future release this test catches it.
     """
+    from selenium import webdriver as selenium_webdriver  # noqa: F401
     from selenium.common import WebDriverException  # noqa: F401
     from selenium.common.exceptions import ElementClickInterceptedException  # noqa: F401
-    from selenium.webdriver import (  # noqa: F401
-        ChromeOptions,
-        EdgeOptions,
-        FirefoxOptions,
-        FirefoxProfile,
-        IeOptions,
-    )
+    from selenium.webdriver.chrome.options import Options as ChromeOptions  # noqa: F401
+    from selenium.webdriver.edge.options import Options as EdgeOptions  # noqa: F401
+    from selenium.webdriver.firefox.firefox_profile import FirefoxProfile  # noqa: F401
+    from selenium.webdriver.firefox.options import Options as FirefoxOptions  # noqa: F401
+    from selenium.webdriver.ie.options import Options as IeOptions  # noqa: F401
     from selenium.webdriver.common.by import By  # noqa: F401
     from selenium.webdriver.common.options import ArgOptions  # noqa: F401
+    from selenium.webdriver.common.virtual_authenticator import VirtualAuthenticatorOptions  # noqa: F401
     from selenium.webdriver.remote.shadowroot import ShadowRoot  # noqa: F401
     from selenium.webdriver.support import expected_conditions  # noqa: F401
+    from selenium.webdriver.support.relative_locator import locate_with  # noqa: F401
     from selenium.webdriver.support.ui import WebDriverWait  # noqa: F401
 
 

--- a/packages/main/tests/python/test_browser.py
+++ b/packages/main/tests/python/test_browser.py
@@ -176,8 +176,28 @@ class TestNetworkInterception:
             "about:blank", headless=True, browser_selection="Chrome"
         )
         with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
-            with pytest.raises(NotImplementedError):
+            with pytest.raises(NotImplementedError, match="Chromium"):
                 library.block_urls("*test*")
+
+    def test_unblock_urls_raises_for_non_chromium(self, library):
+        from unittest.mock import patch, PropertyMock
+
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
+            with pytest.raises(NotImplementedError, match="Chromium"):
+                library.unblock_urls()
+
+    def test_get_browser_logs_performance_raises_for_non_chromium(self, library):
+        from unittest.mock import patch, PropertyMock
+
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
+            with pytest.raises(NotImplementedError, match="performance"):
+                library.get_browser_logs(log_type="performance")
 
     def test_wait_for_network_request(self, library):
         library.open_available_browser(
@@ -234,6 +254,40 @@ class TestVirtualAuthenticator:
         auth_id = library.add_virtual_authenticator(transport="internal")
         assert auth_id
         library.remove_virtual_authenticator()
+
+    def test_add_virtual_authenticator_invalid_protocol(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with pytest.raises(ValueError, match="protocol"):
+            library.add_virtual_authenticator(protocol="fido3")
+
+    def test_add_virtual_authenticator_invalid_transport(self, library):
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with pytest.raises(ValueError, match="transport"):
+            library.add_virtual_authenticator(transport="wifi")
+
+    def test_add_virtual_authenticator_raises_for_non_chromium(self, library):
+        from unittest.mock import patch, PropertyMock
+
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
+            with pytest.raises(NotImplementedError, match="Chromium"):
+                library.add_virtual_authenticator()
+
+    def test_remove_virtual_authenticator_raises_for_non_chromium(self, library):
+        from unittest.mock import patch, PropertyMock
+
+        library.open_available_browser(
+            "about:blank", headless=True, browser_selection="Chrome"
+        )
+        with patch.object(type(library), "is_chromium", new_callable=PropertyMock, return_value=False):
+            with pytest.raises(NotImplementedError, match="Chromium"):
+                library.remove_virtual_authenticator()
 
 
 def test_selenium_api_imports():

--- a/packages/main/tests/resources/relative_locator_test.html
+++ b/packages/main/tests/resources/relative_locator_test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Relative Locator Test Page</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    .row { display: flex; align-items: center; margin: 12px 0; gap: 10px; }
+    label { width: 120px; display: inline-block; }
+    input { width: 200px; }
+    button { margin-top: 16px; }
+  </style>
+</head>
+<body>
+  <form id="login-form">
+    <div class="row">
+      <label id="lbl-username">Username</label>
+      <input id="inp-username" type="text" name="username" placeholder="Username">
+    </div>
+    <div class="row">
+      <label id="lbl-password">Password</label>
+      <input id="inp-password" type="password" name="password" placeholder="Password">
+    </div>
+    <button id="btn-submit" type="button">Login</button>
+  </form>
+</body>
+</html>

--- a/packages/main/uv.lock
+++ b/packages/main/uv.lock
@@ -2809,7 +2809,7 @@ wheels = [
 
 [[package]]
 name = "rpaframework"
-version = "31.1.2"
+version = "31.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2926,7 +2926,7 @@ requires-dist = [
     { name = "rpaframework-core", specifier = ">=12.1.0" },
     { name = "rpaframework-pdf", specifier = ">=10.0.3" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'", specifier = ">=10.0.2" },
-    { name = "selenium", specifier = ">=4.15.2,<5.0.0" },
+    { name = "selenium", specifier = ">=4.16.0,<5.0.0" },
     { name = "simple-salesforce", specifier = ">=1.0.0" },
     { name = "smartsheet-python-sdk", specifier = "==3.0.2" },
     { name = "tenacity", specifier = ">=8.0.1" },

--- a/packages/main/uv.lock
+++ b/packages/main/uv.lock
@@ -2785,7 +2785,8 @@ dependencies = [
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "robotframework" },
     { name = "robotframework-pythonlibcore" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/d5/aa063b493a14cdb2771c23e6d5fdaa90c3d4712f8a086077bc5595aae9b9/robotframework_seleniumlibrary-6.8.0.tar.gz", hash = "sha256:60fb0584b11eabc687e8433134093b764ec011e0e8a9ec417bfdeeab59d748bb", size = 171793, upload-time = "2025-10-04T13:37:07.776Z" }
 wheels = [
@@ -2860,7 +2861,8 @@ dependencies = [
     { name = "rpaframework-core" },
     { name = "rpaframework-pdf" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "simple-salesforce" },
     { name = "smartsheet-python-sdk" },
     { name = "tenacity" },
@@ -2924,7 +2926,7 @@ requires-dist = [
     { name = "rpaframework-core", specifier = ">=12.1.0" },
     { name = "rpaframework-pdf", specifier = ">=10.0.3" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'", specifier = ">=10.0.2" },
-    { name = "selenium", specifier = "==4.15.2" },
+    { name = "selenium", specifier = ">=4.15.2,<5.0.0" },
     { name = "simple-salesforce", specifier = ">=1.0.0" },
     { name = "smartsheet-python-sdk", specifier = "==3.0.2" },
     { name = "tenacity", specifier = ">=8.0.1" },
@@ -2951,7 +2953,8 @@ dependencies = [
     { name = "pillow", version = "12.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "psutil", marker = "sys_platform == 'win32'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uiautomation", marker = "sys_platform == 'win32'" },
     { name = "webdriver-manager" },
 ]
@@ -3367,19 +3370,44 @@ wheels = [
 
 [[package]]
 name = "selenium"
-version = "4.15.2"
+version = "4.32.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "trio", version = "0.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "trio", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "trio-websocket" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version >= '3.10'" },
+resolution-markers = [
+    "python_full_version < '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/44/e86a333a57dd81739126f78c73f2243af2bfb728787a7c66046eb923c02e/selenium-4.15.2.tar.gz", hash = "sha256:22eab5a1724c73d51b240a69ca702997b717eee4ba1f6065bf5d6b44dba01d48", size = 9954413, upload-time = "2023-11-03T21:57:15.432Z" }
+dependencies = [
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "trio", version = "0.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "trio-websocket", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version < '3.10'" },
+    { name = "websocket-client", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/2d/fafffe946099033ccf22bf89e12eede14c1d3c5936110c5f6f2b9830722c/selenium-4.32.0.tar.gz", hash = "sha256:b9509bef4056f4083772abb1ae19ff57247d617a29255384b26be6956615b206", size = 870997, upload-time = "2025-05-02T20:35:27.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/59/aae37fa93e2d4292c3148efcc3066c8ecfe5cfaa72bf8c0b1a5614622cf7/selenium-4.15.2-py3-none-any.whl", hash = "sha256:9e82cd1ac647fb73cf0d4a6e280284102aaa3c9d94f0fa6e6cc4b5db6a30afbf", size = 10175338, upload-time = "2023-11-03T21:57:11.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/37/d07ed9d13e571b2115d4ed6956d156c66816ceec0b03b2e463e80d09f572/selenium-4.32.0-py3-none-any.whl", hash = "sha256:c4d9613f8a45693d61530c9660560fadb52db7d730237bc788ddedf442391f97", size = 9369668, upload-time = "2025-05-02T20:35:24.726Z" },
+]
+
+[[package]]
+name = "selenium"
+version = "4.41.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "trio", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "trio-websocket", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version >= '3.10'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/7c/133d00d6d013a17d3f39199f27f1a780ec2e95d7b9aa997dc1b8ac2e62a7/selenium-4.41.0.tar.gz", hash = "sha256:003e971f805231ad63e671783a2b91a299355d10cefb9de964c36ff3819115aa", size = 937872, upload-time = "2026-02-20T03:42:06.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/d6/e4160989ef6b272779af6f3e5c43c3ba9be6687bdc21c68c3fb220e555b3/selenium-4.41.0-py3-none-any.whl", hash = "sha256:b8ccde8d2e7642221ca64af184a92c19eee6accf2e27f20f30472f5efae18eb1", size = 9532858, upload-time = "2026-02-20T03:42:03.218Z" },
 ]
 
 [[package]]
@@ -3755,6 +3783,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/4f/6e44478908c5133f680378d687f14ecaa99feed2c535344fcf68d8d21500/webdriver_manager-4.0.2.tar.gz", hash = "sha256:efedf428f92fd6d5c924a0d054e6d1322dd77aab790e834ee767af392b35590f", size = 25940, upload-time = "2024-07-25T08:13:49.331Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/b5/3bd0b038d80950ec13e6a2c8d03ed8354867dc60064b172f2f4ffac8afbe/webdriver_manager-4.0.2-py2.py3-none-any.whl", hash = "sha256:75908d92ecc45ff2b9953614459c633db8f9aa1ff30181cefe8696e312908129", size = 27778, upload-time = "2024-07-25T08:13:47.917Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4630,7 +4630,7 @@ wheels = [
 
 [[package]]
 name = "rpaframework"
-version = "31.1.1"
+version = "31.2.0"
 source = { editable = "packages/main" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -4740,9 +4740,9 @@ requires-dist = [
     { name = "robotframework-seleniumlibrary", specifier = ">=6.7.1" },
     { name = "robotframework-seleniumtestability", specifier = ">=2.0.0" },
     { name = "rpaframework-core", specifier = ">=12.1.0" },
-    { name = "rpaframework-pdf", specifier = ">=10.0.2" },
+    { name = "rpaframework-pdf", specifier = ">=10.0.3" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'", specifier = ">=10.0.2" },
-    { name = "selenium", specifier = "==4.15.2" },
+    { name = "selenium", specifier = ">=4.15.2,<5.0.0" },
     { name = "simple-salesforce", specifier = ">=1.0.0" },
     { name = "smartsheet-python-sdk", specifier = "==3.0.2" },
     { name = "tenacity", specifier = ">=8.0.1" },
@@ -4981,7 +4981,7 @@ wheels = [
 
 [[package]]
 name = "rpaframework-pdf"
-version = "10.0.2"
+version = "10.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -4994,9 +4994,9 @@ dependencies = [
     { name = "robotframework" },
     { name = "rpaframework-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/a4/1eb030ca50a8c89455b4ae9e9d093dd356d163c9aacaca5dcbe635086cfe/rpaframework_pdf-10.0.2.tar.gz", hash = "sha256:5ae5343c4035e6facceb943a0303a5bf472d68b1c7ab29402ab618bba51010c9", size = 4559220, upload-time = "2026-02-02T12:36:14.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a0/f36fa3a1211f0ea16ff9050a0a4bc973b49c671726f1ebd793db08e53c87/rpaframework_pdf-10.0.3.tar.gz", hash = "sha256:6d36aeacbe02625738cf57ada6dbac5fc584bf711d455da6c2004a9ecc5fb111", size = 4575911, upload-time = "2026-03-06T17:42:04.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/c3/03e175076042133c2199eab6a341c788c06adfc654dbbebb899ef638d3c1/rpaframework_pdf-10.0.2-py3-none-any.whl", hash = "sha256:343da57943a575a9ecc21d681543d3008e7350b00b5d608788bac83030a175bb", size = 612605, upload-time = "2026-02-02T12:36:11.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4f/f815398a6b4b2777d91657e82fc35430682f5fe157f3067133332db7d753/rpaframework_pdf-10.0.3-py3-none-any.whl", hash = "sha256:095d73c37aff2fa601560650cfaf9ad511da5832250c779a611eed146ddecc83", size = 612603, upload-time = "2026-03-06T17:42:01.059Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4589,7 +4589,8 @@ dependencies = [
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "robotframework" },
     { name = "robotframework-pythonlibcore" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/d5/aa063b493a14cdb2771c23e6d5fdaa90c3d4712f8a086077bc5595aae9b9/robotframework_seleniumlibrary-6.8.0.tar.gz", hash = "sha256:60fb0584b11eabc687e8433134093b764ec011e0e8a9ec417bfdeeab59d748bb", size = 171793, upload-time = "2025-10-04T13:37:07.776Z" }
 wheels = [
@@ -4683,7 +4684,8 @@ dependencies = [
     { name = "rpaframework-core" },
     { name = "rpaframework-pdf" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "simple-salesforce" },
     { name = "smartsheet-python-sdk" },
     { name = "tenacity" },
@@ -4742,7 +4744,7 @@ requires-dist = [
     { name = "rpaframework-core", specifier = ">=12.1.0" },
     { name = "rpaframework-pdf", specifier = ">=10.0.3" },
     { name = "rpaframework-windows", marker = "sys_platform == 'win32'", specifier = ">=10.0.2" },
-    { name = "selenium", specifier = ">=4.15.2,<5.0.0" },
+    { name = "selenium", specifier = ">=4.16.0,<5.0.0" },
     { name = "simple-salesforce", specifier = ">=1.0.0" },
     { name = "smartsheet-python-sdk", specifier = "==3.0.2" },
     { name = "tenacity", specifier = ">=8.0.1" },
@@ -4787,7 +4789,8 @@ dependencies = [
     { name = "pillow", version = "12.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "psutil", marker = "sys_platform == 'win32'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "selenium" },
+    { name = "selenium", version = "4.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "selenium", version = "4.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "uiautomation", marker = "sys_platform == 'win32'" },
     { name = "webdriver-manager" },
 ]
@@ -5395,19 +5398,55 @@ wheels = [
 
 [[package]]
 name = "selenium"
-version = "4.15.2"
+version = "4.32.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "trio", version = "0.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "trio", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "trio-websocket" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version >= '3.10'" },
+resolution-markers = [
+    "python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.10' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.10' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/44/e86a333a57dd81739126f78c73f2243af2bfb728787a7c66046eb923c02e/selenium-4.15.2.tar.gz", hash = "sha256:22eab5a1724c73d51b240a69ca702997b717eee4ba1f6065bf5d6b44dba01d48", size = 9954413, upload-time = "2023-11-03T21:57:15.432Z" }
+dependencies = [
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "trio", version = "0.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "trio-websocket", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version < '3.10'" },
+    { name = "websocket-client", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/2d/fafffe946099033ccf22bf89e12eede14c1d3c5936110c5f6f2b9830722c/selenium-4.32.0.tar.gz", hash = "sha256:b9509bef4056f4083772abb1ae19ff57247d617a29255384b26be6956615b206", size = 870997, upload-time = "2025-05-02T20:35:27.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/59/aae37fa93e2d4292c3148efcc3066c8ecfe5cfaa72bf8c0b1a5614622cf7/selenium-4.15.2-py3-none-any.whl", hash = "sha256:9e82cd1ac647fb73cf0d4a6e280284102aaa3c9d94f0fa6e6cc4b5db6a30afbf", size = 10175338, upload-time = "2023-11-03T21:57:11.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/37/d07ed9d13e571b2115d4ed6956d156c66816ceec0b03b2e463e80d09f572/selenium-4.32.0-py3-none-any.whl", hash = "sha256:c4d9613f8a45693d61530c9660560fadb52db7d730237bc788ddedf442391f97", size = 9369668, upload-time = "2025-05-02T20:35:24.726Z" },
+]
+
+[[package]]
+name = "selenium"
+version = "4.41.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.10.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "trio", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "trio-websocket", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, extra = ["socks"], marker = "python_full_version >= '3.10'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/7c/133d00d6d013a17d3f39199f27f1a780ec2e95d7b9aa997dc1b8ac2e62a7/selenium-4.41.0.tar.gz", hash = "sha256:003e971f805231ad63e671783a2b91a299355d10cefb9de964c36ff3819115aa", size = 937872, upload-time = "2026-02-20T03:42:06.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/d6/e4160989ef6b272779af6f3e5c43c3ba9be6687bdc21c68c3fb220e555b3/selenium-4.41.0-py3-none-any.whl", hash = "sha256:b8ccde8d2e7642221ca64af184a92c19eee6accf2e27f20f30472f5efae18eb1", size = 9532858, upload-time = "2026-02-20T03:42:03.218Z" },
 ]
 
 [[package]]
@@ -6177,6 +6216,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/4f/6e44478908c5133f680378d687f14ecaa99feed2c535344fcf68d8d21500/webdriver_manager-4.0.2.tar.gz", hash = "sha256:efedf428f92fd6d5c924a0d054e6d1322dd77aab790e834ee767af392b35590f", size = 25940, upload-time = "2024-07-25T08:13:49.331Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/b5/3bd0b038d80950ec13e6a2c8d03ed8354867dc60064b172f2f4ffac8afbe/webdriver_manager-4.0.2-py2.py3-none-any.whl", hash = "sha256:75908d92ecc45ff2b9953614459c633db8f9aa1ff30181cefe8696e312908129", size = 27778, upload-time = "2024-07-25T08:13:47.917Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fixes #1312 — `selenium==4.15.2` exact pin prevented installing `rpaframework` alongside `appium-python-client` (Appium 3)
- Constraint changed to `selenium>=4.16.0,<5.0.0` — allows any 4.x release ≥ 4.16.0 (4.16 needed for native `FirefoxOptions.binary_location`)
- Selenium upgraded in lock file: **4.15.2 → 4.41.0**
- Bumped `rpaframework` version: **31.1.2 → 31.2.0**
- Bumped `rpaframework-core` version: **12.1.0 → 12.1.1** (EdgeDriver BOM fix, see below)

## Changes

### Bug fixes / compatibility
| File | Change |
|------|--------|
| `packages/main/pyproject.toml` | `==4.15.2` → `>=4.16.0,<5.0.0`, version bump to 31.2.0 |
| `packages/main/uv.lock` + root `uv.lock` | selenium 4.15.2 → 4.41.0 |
| `Selenium.py` imports | Switched to concrete submodule paths to fix pylint `no-name-in-module` |
| `Selenium.py` `_send_command_and_get_result` | Replaced removed `_url` HTTP hack with `execute_cdp_cmd`; added Chromium guard |
| `Selenium.py` `FirefoxOptions` | Removed subclass workaround for `binary._start_cmd` (obsolete since 4.16) |
| `Selenium.py` `add_virtual_authenticator` | Use constructor kwargs instead of post-construction attribute assignment |

### EdgeDriver UTF-16 BOM fix (`rpaframework-core 12.1.1`)

**Root cause:** Microsoft's `LATEST_RELEASE_<major>_WINDOWS` endpoint returns the version string as UTF-16 LE with a BOM (`\xff\xfe` bytes). `requests` decodes this to a Python string starting with `\ufeff`. `webdriver-manager 4.0.2` only calls `.rstrip()` which strips trailing whitespace but leaves the leading `\ufeff` intact. That BOM gets URL-encoded as `%EF%BB%BF` in the download URL → 404.

**Reproducer:**
```python
import requests
r = requests.get("https://msedgedriver.microsoft.com/LATEST_RELEASE_145_WINDOWS")
print(repr(r.text[:20]))  # '\ufeff145.0.3800.97\r\n'
```

**Fix:** `EdgeChromiumDriver` subclass in `RPA.core.webdriver` overrides `get_latest_release_version()` and `get_stable_release_version()` to strip `\ufeff` before returning. Registered via a matching `EdgeChromiumDriverManager` subclass.

This is a bug in `webdriver-manager` 4.0.2 (latest). The fix lives in `rpaframework-core` so users are not blocked waiting for an upstream release.

**Release order after merge:**
1. Publish `rpaframework-core 12.1.1`
2. Bump `rpaframework-core>=12.1.1` in `packages/main/pyproject.toml`, regenerate lock, publish `rpaframework 31.2.0`

### New keywords (selenium 4.x)
| Keyword | Description |
|---------|-------------|
| `Find Element Above/Below/To Left Of/To Right Of/Near` | Relative locators (selenium 4.x) |
| `Get Browser Logs` | Chromium-only; returns CDP log entries |
| `Block URLs` / `Unblock URLs` | CDP network interception |
| `Wait For Network Request` | Polls `window.performance` resources; raises `TimeoutException` |
| `Add Virtual Authenticator` / `Remove Virtual Authenticator` | WebAuthn testing (Chromium-only) |

All Chromium-only keywords raise `NotImplementedError` with a clear message on non-Chromium drivers.

### Tests & tooling
| File | Change |
|------|--------|
| `test_browser.py` | `TestRelativeLocators`, `TestBrowserLogs`, `TestNetworkInterception`, `TestVirtualAuthenticator` classes; updated import guard |
| `tests/resources/relative_locator_test.html` | New HTML fixture for relative locator tests |
| `packages/core/tests/python/test_edge_driver.py` | Standalone EdgeDriver integration test (run on Windows); verifies BOM strip + download + headless session |
| `.github/workflows/main.yaml` | `build-wheel` PR job: builds wheel, uploads artifact, posts comment with download link; pinned to Python 3.11 |
| `packages/main/scripts/pre-push.sh` | Pre-push hook: pylint + fast tests + AI review before every push |
| `packages/main/scripts/ai-review.sh` | Pipes branch diff through `claude --print` for local Cursor-bot-style review (advisory, never blocks push) |

## Test plan

- [ ] CI passes on all matrix (Windows/Ubuntu/macOS × Python 3.9/3.10/3.11)
- [ ] `test_selenium_api_imports` — all production selenium imports remain resolvable
- [ ] `test_selenium_constraint_is_not_exact_pin` — guards against re-introducing an exact pin
- [ ] `test_edge_driver.py` — run manually on Windows where Edge is installed; verifies BOM strip, EdgeDriver download, and headless session

🤖 Generated with [Claude Code](https://claude.com/claude-code)