### PR TITLE
fix(windows): raise when Select cannot find a value

### DIFF
--- a/packages/windows/src/RPA/Windows/keywords/action.py
+++ b/packages/windows/src/RPA/Windows/keywords/action.py
@@ -237,9 +237,13 @@ class ActionKeywords(ActionMethods):
             # NOTE(cmin764): This is not supposed to work on `*Pattern` or `TextRange`
             #  objects. (works with `Control`s and its derived flavors only, like a
             #  combobox)
-            element.item.Select(
+            selected = element.item.Select(
                 value, simulateMove=self.ctx.simulate_move, waitTime=self.ctx.wait_time
             )
+            if selected is False:
+                raise ActionNotPossible(
+                    f"Element {locator!r} could not select value {value!r}"
+                )
         else:
             raise ActionNotPossible(
                 f"Element {locator!r} does not support selection (try with"

--- a/packages/windows/tests/python/test_windows.py
+++ b/packages/windows/tests/python/test_windows.py
@@ -86,6 +86,25 @@ def test_select_raises_when_value_cannot_be_selected():
     )
 
 
+def test_select_succeeds_when_select_returns_none():
+    """UIAutomation Select() returns None on success — must not raise.
+
+    The guard uses `is False` (identity), not a falsy check, so that a None
+    return (typical for COM void methods) is treated as success.
+    """
+    ctx = mock.Mock()
+    ctx.simulate_move = False
+    ctx.wait_time = 0.5
+    element = mock.Mock()
+    element.item.Select.return_value = None
+    ctx.get_element.return_value = element
+
+    keywords = ActionKeywords(ctx)
+    result = keywords.select("id:FontSizeComboBox", "22")
+
+    assert result is element
+
+
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows required")
 def test_list_windows_control_window_click_error_scenario(library):
     """Test error handling when window or element is not found.

--- a/packages/windows/tests/python/test_windows.py
+++ b/packages/windows/tests/python/test_windows.py
@@ -3,6 +3,8 @@ from unittest import mock
 import pytest
 
 from RPA.Windows import Windows
+from RPA.Windows.keywords.action import ActionKeywords
+from RPA.Windows.keywords.context import ActionNotPossible
 from RPA.Windows.utils import IS_WINDOWS
 from RPA.core.windows.context import ElementNotFound, WindowControlError
 
@@ -63,6 +65,25 @@ def test_coordinates_clicking(mock_get_element, library, offset, x, y):
     item.robocorp_click_offset = offset
     library.click("MyButton")
     item.Click.assert_called_once_with(x=x, y=y, simulateMove=False, waitTime=0.5)
+
+
+def test_select_raises_when_value_cannot_be_selected():
+    ctx = mock.Mock()
+    ctx.logger = mock.Mock()
+    ctx.simulate_move = False
+    ctx.wait_time = 0.5
+    element = mock.Mock()
+    element.item.Select.return_value = False
+    ctx.get_element.return_value = element
+
+    keywords = ActionKeywords(ctx)
+
+    with pytest.raises(ActionNotPossible, match="could not select value"):
+        keywords.select("id:FontSizeComboBox", "22")
+
+    element.item.Select.assert_called_once_with(
+        "22", simulateMove=False, waitTime=0.5
+    )
 
 
 @pytest.mark.skipif(not IS_WINDOWS, reason="Windows required")


### PR DESCRIPTION
## Summary
- treat an explicit `False` return from UIAutomation `Select()` as a failed selection
- raise `ActionNotPossible` when the requested combo box value is not available
- add a focused regression test for the failure path

Closes #1150.

## Test plan
- `python -m pytest packages/windows/tests/python/test_windows.py -q -p no:cacheprovider`
