### PR TITLE
fix(core): lower truststore log messages from INFO to DEBUG

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -12,7 +12,7 @@ Latest versions
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-No changes planned yet for the next release.
+- ``rpaframework-core``: Lower the truststore certificate-store log messages from ``INFO`` to ``DEBUG`` so they no longer appear on every run's console (fixes :issue:`1220`, :issue:`1093`, :issue:`1210`).
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/core/src/RPA/core/certificates.py
+++ b/packages/core/src/RPA/core/certificates.py
@@ -73,13 +73,13 @@ def use_system_certificates():
             LOGGER.debug("Dependency `truststore` is not installed!")
         else:
             truststore.inject_into_ssl()
-            LOGGER.info(
+            LOGGER.debug(
                 "Truststore injection done, using system certificate store to validate"
                 " HTTPS."
             )
             return
 
-    LOGGER.info(
+    LOGGER.debug(
         "Truststore not in use, HTTPS traffic validated against `certifi` package."
         " (requires Python %s and 'pip' %s at minimum)",
         ".".join(str(nr) for nr in py_version),


### PR DESCRIPTION
## Summary

The `RPA.core.certificates` truststore status messages were logged at `INFO` level on every import, so they appeared on the console for **every** robot/script run:

```
RPA.core.certificates - INFO - Truststore injection done, using system certificate store to validate HTTPS.
RPA.core.certificates - INFO - Truststore not in use, HTTPS traffic validated against `certifi` package.
```

These are diagnostic, not actionable for end users. This lowers both to `DEBUG`.

## Changes
- `packages/core/src/RPA/core/certificates.py`: `LOGGER.info` → `LOGGER.debug` for both truststore status messages.
- Release note added under *Upcoming release*.

Fixes #1220, fixes #1093, fixes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)