### PR TITLE
fix(security): sanitize archive extraction paths in RPA.Archive (zip slip)

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -12,7 +12,13 @@ Latest versions
 `Upcoming release <https://github.com/robocorp/rpaframework/projects/3#column-16713994>`_
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-No changes planned yet for the next release.
+- **Security:** ``RPA.Archive``: Fix a Zip Slip path traversal vulnerability (CWE-22) in
+  ``Extract Archive`` — archive members with path traversal sequences (e.g.
+  ``../../evil.py``) could previously be extracted outside the requested destination
+  directory. Extraction now validates that every member resolves within the destination
+  before extracting, raising ``ValueError`` otherwise (fixes :issue:`1339`, :issue:`1340`).
+
+- ``rpaframework`` **32.0.2**
 
 `Released <https://pypi.org/project/rpaframework/#history>`_
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/main/pyproject.toml
+++ b/packages/main/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rpaframework"
-version = "32.0.1"
+version = "32.0.2"
 description = "A collection of tools and libraries for RPA"
 authors = [{name = "RPA Framework", email = "rpafw@robocorp.com"}]
 license = {text = "Apache-2.0"}

--- a/packages/main/src/RPA/Archive.py
+++ b/packages/main/src/RPA/Archive.py
@@ -25,6 +25,21 @@ def convert_date(timestamp):
     return formatted_date
 
 
+def _check_extraction_safety(names, dest: Path) -> None:
+    """Raise ValueError if extracting any of `names` under `dest` would escape it.
+
+    Guards against Zip Slip / path traversal (CWE-22) via archive members
+    containing sequences like ``../../evil.py``.
+    """
+    dest = dest.resolve()
+    for name in names:
+        target = (dest / name).resolve()
+        if target != dest and dest not in target.parents:
+            raise ValueError(
+                f"Refusing to extract {name!r}: path escapes destination directory"
+            )
+
+
 def list_files_in_directory(folder, recursive=False, include=None, exclude=None):
     filelist = []
     for rootdir, _, files in os.walk(folder):
@@ -373,15 +388,19 @@ class Archive:
             members = [members]
         if zipfile.is_zipfile(archive_name):
             with zipfile.ZipFile(archive_name, "r") as f:
+                names = members if members else f.namelist()
+                _check_extraction_safety(names, root)
                 if members:
                     f.extractall(path=root, members=members)
                 else:
                     f.extractall(path=root)
         elif tarfile.is_tarfile(archive_name):
-            members = map(tarfile.TarInfo, members) if members else None
             with tarfile.open(archive_name, "r") as f:
-                if members:
-                    f.extractall(path=root, members=members)
+                names = members if members else [m.name for m in f.getmembers()]
+                _check_extraction_safety(names, root)
+                tar_members = map(tarfile.TarInfo, members) if members else None
+                if tar_members:
+                    f.extractall(path=root, members=tar_members)
                 else:
                     f.extractall(path=root)
 

--- a/packages/main/tests/python/test_archive.py
+++ b/packages/main/tests/python/test_archive.py
@@ -1,0 +1,61 @@
+import tarfile
+import zipfile
+
+import pytest
+from RPA.Archive import Archive
+
+
+@pytest.fixture
+def lib():
+    return Archive()
+
+
+def _make_traversal_zip(path):
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("../evil_zip.txt", "pwned")
+    return path
+
+
+def _make_traversal_tar(path):
+    with tarfile.open(path, "w") as tf:
+        info = tarfile.TarInfo(name="../evil_tar.txt")
+        data = b"pwned"
+        info.size = len(data)
+        import io
+
+        tf.addfile(info, io.BytesIO(data))
+    return path
+
+
+def test_extract_archive_rejects_zip_slip(lib, tmp_path):
+    archive = _make_traversal_zip(tmp_path / "evil.zip")
+    extract_dir = tmp_path / "extracted"
+    extract_dir.mkdir()
+
+    with pytest.raises(ValueError):
+        lib.extract_archive(str(archive), str(extract_dir))
+
+    assert not (tmp_path / "evil_zip.txt").exists()
+
+
+def test_extract_archive_rejects_tar_slip(lib, tmp_path):
+    archive = _make_traversal_tar(tmp_path / "evil.tar")
+    extract_dir = tmp_path / "extracted"
+    extract_dir.mkdir()
+
+    with pytest.raises(ValueError):
+        lib.extract_archive(str(archive), str(extract_dir))
+
+    assert not (tmp_path / "evil_tar.txt").exists()
+
+
+def test_extract_archive_allows_normal_zip(lib, tmp_path):
+    archive = tmp_path / "ok.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("hello.txt", "hi")
+    extract_dir = tmp_path / "extracted"
+    extract_dir.mkdir()
+
+    lib.extract_archive(str(archive), str(extract_dir))
+
+    assert (extract_dir / "hello.txt").read_text() == "hi"


### PR DESCRIPTION
## Summary
- Fixes a Zip Slip / path traversal vulnerability (CWE-22) in `RPA.Archive.Extract Archive`. Both the `zipfile` and `tarfile` extraction branches called `extractall()` without validating member paths, so a crafted archive with an entry like `../../evil.py` could write files outside the requested destination directory.
- Adds `_check_extraction_safety()` which resolves each member's destination path and raises `ValueError` if it would escape the target directory, applied before extraction for both zip and tar archives (whole-archive and selected-`members` extraction).
- Adds regression tests (`tests/python/test_archive.py`) covering rejected zip/tar traversal archives and a normal extraction still working.
- Bumps `rpaframework` to 32.0.2 and updates release notes.

Fixes #1339, #1340.

## Test plan
- [x] `uv run pytest tests/python/test_archive.py -vv` — 3 passed (rejects zip slip, rejects tar slip, normal extraction still works)
- [x] `invoke code.test-robot -r archive` — 19/19 existing Robot Framework tests still pass (no regression to normal extraction behavior)
- [x] `pylint` clean on `Archive.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)