### PR TITLE
fix(security): bump soupsieve>=2.8.4 in lock files (CVE-2026-49476)

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -18,6 +18,10 @@ Latest versions
   directory. Extraction now validates that every member resolves within the destination
   before extracting, raising ``ValueError`` otherwise (fixes :issue:`1339`, :issue:`1340`).
 
+- **Security:** Bump ``soupsieve`` ≥2.8.4 (HIGH — memory exhaustion via large
+  comma-separated selector lists, CVE-2026-49476) in the root and ``rpaframework``
+  lock files.
+
 - ``rpaframework`` **32.0.2**
 
 `Released <https://pypi.org/project/rpaframework/#history>`_

--- a/packages/main/uv.lock
+++ b/packages/main/uv.lock
@@ -2119,7 +2119,7 @@ wheels = [
 
 [[package]]
 name = "rpaframework"
-version = "32.0.1"
+version = "32.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2589,11 +2589,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3129,7 +3129,7 @@ wheels = [
 
 [[package]]
 name = "rpaframework"
-version = "32.0.1"
+version = "32.0.2"
 source = { editable = "packages/main" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -3834,11 +3834,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fixes 4 open Dependabot alerts for `soupsieve` (HIGH — memory exhaustion via large comma-separated selector lists, CVE-2026-49476), affecting the root workspace lock and `packages/main/uv.lock` (transitive via `beautifulsoup4`).
- Ran `uv lock --upgrade-package soupsieve` in both lock files; no `pyproject.toml` constraint changes needed since this is a transitive dependency.
- Added a release-notes entry under the upcoming `rpaframework` 32.0.2 release.

## Test plan
- [x] `uv lock --upgrade-package soupsieve` run in root and `packages/main`, verified `soupsieve` now resolves to 2.8.4 in both lock files
- [x] Confirmed diff is scoped to `soupsieve` version bump (plus the lock catching up to the already-set `rpaframework` 32.0.2 version stamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)